### PR TITLE
reset base64-js dependency version to ~0.0.4 because feross's upstream PR was accepted.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "buffer module compatibility for browserify (backed by ArrayBuffer so its fast!)",
   "main": "index.js",
   "dependencies": {
-    "base64-js": "feross/base64-js",
+    "base64-js": "~0.0.4",
     "ieee754": "~1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hey feross, is it cool with you if we reset this?  I'm trying to install native-buffer-browserify and getting some errors related to this version number.  Possible that the root cause is unrelated (read: I've never used npm before and have basically no idea what I'm doing), but this seems like positive cleanup to do in any case.

Thanks!
