### PR TITLE
surrogate pair tests: use escape sequences

### DIFF
--- a/test/buffer.js
+++ b/test/buffer.js
@@ -264,7 +264,7 @@ test('base64 strings without padding', function (t) {
 
 test('detect utf16 surrogate pairs', function(t) {
   t.plan(1)
-  var text = 'Ì†ΩÌ∏∏Ì†ΩÌ≤≠Ì†ΩÌ±ç'
+  var text = '\uD83D\uDE38' + '\uD83D\uDCAD' + '\uD83D\uDC4D'
   var buf = new B(text)
   t.equal(text, buf.toString())
   t.end()
@@ -272,7 +272,7 @@ test('detect utf16 surrogate pairs', function(t) {
 
 test('throw on orphaned utf16 surrogate lead code point', function(t) {
   t.plan(1)
-  var text = 'Ì†ΩÌ†ΩÌ≤≠Ì†ΩÌ±ç'
+  var text = '\uD83D\uDE38' + '\uD83D' + '\uD83D\uDC4D'
   var err
   try {
     var buf = new B(text)
@@ -285,7 +285,7 @@ test('throw on orphaned utf16 surrogate lead code point', function(t) {
 
 test('throw on orphaned utf16 surrogate trail code point', function(t) {
   t.plan(1)
-  var text = 'Ì†ΩÌ∏∏Ì†ΩÌ≤≠Ì±ç'
+  var text = '\uD83D\uDE38' + '\uDCAD' + '\uD83D\uDC4D'
   var err
   try {
     var buf = new B(text)


### PR DESCRIPTION
interestingly, node's buffer doesn't throw when attempting to encode these half surrogates, it just generates utf8 garbage...

the reason the (testling) tests weren't passing is related to this: when browserifying, the test source actually has to pass through node's buffers and so the tests themselves were being improperly generated.

this patch fixes that by using unicode escape sequences in the tests instead of the actual characters.
