### PR TITLE
Buffer.isBuffer() returns explicit true/false, fixed for non-Uint8Array implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ function Buffer (subject, encoding, noZero) {
     // Fallback: Return this instance of Buffer
     buf = this
     buf.length = length
+    buf._isBuffer = true
   }
 
   var i
@@ -121,7 +122,7 @@ Buffer.isEncoding = function (encoding) {
 }
 
 Buffer.isBuffer = function (b) {
-  return b && b._isBuffer
+  return (b != null && b._isBuffer) || false
 }
 
 Buffer.byteLength = function (str, encoding) {

--- a/test/is-buffer.js
+++ b/test/is-buffer.js
@@ -1,0 +1,10 @@
+var B = require('../index.js').Buffer
+var test = require('tape')
+
+test('Buffer.isBuffer', function (t) {
+  t.plan(3)
+  t.equal(B.isBuffer(new B('hey', 'utf8')), true)
+  t.equal(B.isBuffer(new B([1, 2, 3], 'utf8')), true)
+  t.equal(B.isBuffer('hey'), false)
+  t.end()
+})


### PR DESCRIPTION
After upgrading Browserify to v3 on a project, our tests started failing as `Buffer.isBuffer()` didn't explicitly return `false` if not a buffer.

I also noticed that `Buffer.isBuffer()` would return `false` each time if using the non-`Uint8Array` fallback; this pull request fixes that, too.
