### PR TITLE
Fix typed array check in Safari

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,17 +21,15 @@ Buffer.poolSize = 8192
  *   === false   Use Object implementation (compatible down to IE6)
  */
 Buffer._useTypedArrays = (function () {
-   // Detect if browser supports Typed Arrays. Supported browsers are IE 10+,
-   // Firefox 4+, Chrome 7+, Safari 5.1+, Opera 11.6+, iOS 4.2+.
-  if (typeof Uint8Array !== 'function' || typeof ArrayBuffer !== 'function')
-    return false
-
+  // Detect if browser supports Typed Arrays. Supported browsers are IE 10+,
+  // Firefox 4+, Chrome 7+, Safari 5.1+, Opera 11.6+, iOS 4.2+.
   // Does the browser support adding properties to `Uint8Array` instances? If
   // not, then that's the same as no `Uint8Array` support. We need to be able to
   // add all the node Buffer API methods.
   // Bug in Firefox 4-29, now fixed: https://bugzilla.mozilla.org/show_bug.cgi?id=695438
   try {
-    var arr = new Uint8Array(0)
+    var buf = new ArrayBuffer(0)
+    var arr = new Uint8Array(buf)
     arr.foo = function () { return 42 }
     return 42 === arr.foo() &&
         typeof arr.subarray === 'function' // Chrome 9-10 lack `subarray`


### PR DESCRIPTION
Unfortunately, in Safari `typeof Uint8Array` and `typeof ArrayBuffer` return `'object'` instead of `'function'`, so typed arrays were not being used there. We can check `Uint8Array.constructor` to see if its a function cross browser, but we'd also have to check for null and undefined first. I think it's easier just to try constructing one in the try..catch block that is already there.
