### PR TITLE
remove redundant code unit size check

### DIFF
--- a/index.js
+++ b/index.js
@@ -371,7 +371,7 @@ function base64Write (buf, string, offset, length) {
 }
 
 function utf16leWrite (buf, string, offset, length) {
-  var charsWritten = blitBuffer(utf16leToBytes(string, buf.length - offset), buf, offset, length, 2)
+  var charsWritten = blitBuffer(utf16leToBytes(string, buf.length - offset), buf, offset, length)
   return charsWritten
 }
 
@@ -1292,8 +1292,7 @@ function base64ToBytes (str) {
   return base64.toByteArray(base64clean(str))
 }
 
-function blitBuffer (src, dst, offset, length, unitSize) {
-  if (unitSize) length -= length % unitSize
+function blitBuffer (src, dst, offset, length) {
   for (var i = 0; i < length; i++) {
     if ((i + offset >= dst.length) || (i >= src.length))
       break


### PR DESCRIPTION
e6fddaa9238c815daaf5e61d541a45bc5ef63105 handles this now, so I don't think there is any reason to keep this (from dff29085b184e9c137514b7cc2da422164e89765) hanging around.