### PR TITLE
Fix issue with setting constructor in Safari 5

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,11 +39,14 @@ var rootParent = {}
  * get the Object implementation, which is slower but will work correctly.
  */
 Buffer.TYPED_ARRAY_SUPPORT = (function () {
+  function Foo () {}
   try {
     var buf = new ArrayBuffer(0)
     var arr = new Uint8Array(buf)
     arr.foo = function () { return 42 }
-    return arr.foo() === 42 && // typed array instances can be augmented
+    arr.constructor = Foo
+    return arr.constructor === Foo && // constructor can be set
+        arr.foo() === 42 && // typed array instances can be augmented
         typeof arr.subarray === 'function' && // chrome 9-10 lack `subarray`
         new Uint8Array(1).subarray(1, 1).byteLength === 0 // ie10 has broken `subarray`
   } catch (e) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -2,6 +2,12 @@ var B = require('../').Buffer
 var test = require('tape')
 if (process.env.OBJECT_IMPL) B.TYPED_ARRAY_SUPPORT = false
 
+test('buf.constructor is Buffer', function (t) {
+  var buf = new B([1, 2])
+  t.strictEqual(buf.constructor, B)
+  t.end()
+})
+
 test('convert to Uint8Array in modern browsers', function (t) {
   if (B.TYPED_ARRAY_SUPPORT) {
     var buf = new B([1, 2])


### PR DESCRIPTION
Safari 5 does not allow setting the `constructor` property of `Uint8Array` instances. See [this demonstration][dem].

This behaivor was not being tested, but was depended on by various end-users of *buffer* (e.g., [here in *http-browserify*][ex]).

I've made the following changes:

1. Added a test for the `constructor` property getting set properly ([failed in Safari 5][sl fail]).
1. Changed `TYPED_ARRAY_SUPPORT` to be `false` if the constructor cannot get set properly, causing the object fallback to be used instead ([passed in Safari 5][sl pass]).

I ran zuul using Sauce Labs and all tests pass.

[dem]: http://i.imgur.com/ShU3Bym.png
[sl fail]: https://saucelabs.com/beta/tests/c99d86b2a82944539bbb1fe25a8506d3
[sl pass]: https://saucelabs.com/beta/tests/3c3c94eb5c9e42fcaf25e3cb275b586a
[ex]: https://github.com/substack/http-browserify/blob/17b2990010ebd39461d1117c1e2c50c25eab869f/lib/request.js#L134