### PR TITLE
Fix base 64 character exclusion regex 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1290,7 +1290,7 @@ Buffer._augment = function _augment (arr) {
   return arr
 }
 
-var INVALID_BASE64_RE = /[^+\/0-9A-z\-]/g
+var INVALID_BASE64_RE = /[^+\/0-9A-Za-z\-]/g
 
 function base64clean (str) {
   // Node strips out invalid characters like \n and \t from the string, base64-js does not

--- a/test/base64.js
+++ b/test/base64.js
@@ -37,3 +37,11 @@ test('base64: tab characters in base64 - should get stripped', function (t) {
   )
   t.end()
 })
+
+test('base64: invalid non-alphanumeric characters -- should be stripped', function (t) {
+  t.equal(
+    new B('!"#$%&\'()*,.:;<=>?@[\\]^`{|}~', 'base64').toString('utf8'),
+    ''
+  )
+  t.end()
+})


### PR DESCRIPTION
Using [A-z] in the regex brings in non-alphanumeric characters between the uppercase and lowercase alphabets, meaning the following chars were not correctly stripped from base 64 strings: left and right square bracket, backslash, caret, underline, and backtick. Explicitly separating the uppercase and lowercase letter ranges fixes this.