### PR TITLE
descending copy from end

### DIFF
--- a/index.js
+++ b/index.js
@@ -1171,9 +1171,16 @@ Buffer.prototype.copy = function copy (target, targetStart, start, end) {
   }
 
   var len = end - start
+  var i
 
-  if (len < 1000 || !Buffer.TYPED_ARRAY_SUPPORT) {
-    for (var i = 0; i < len; i++) {
+  if (this === target && start < targetStart && targetStart < end) {
+    // descending copy from end
+    for (i = len - 1; i >= 0; i--) {
+      target[i + targetStart] = this[i + start]
+    }
+  } else if (len < 1000 || !Buffer.TYPED_ARRAY_SUPPORT) {
+    // ascending copy from start
+    for (i = 0; i < len; i++) {
       target[i + targetStart] = this[i + start]
     }
   } else {

--- a/test/methods.js
+++ b/test/methods.js
@@ -100,6 +100,17 @@ test('copy() after slice()', function (t) {
   t.end()
 })
 
+test('copy() ascending and descending', function (t) {
+  var b
+  b = new B('abcdefghij')
+  b.copy(b, 0, 3, 10) // ascending copy
+  t.equal(b.toString(), 'defghijhij')
+  b = new B('abcdefghij')
+  b.copy(b, 3, 0, 7) // descending copy
+  t.equal(b.toString(), 'abcabcdefg')
+  t.end()
+})
+
 test('buffer.slice sets indexes', function (t) {
   t.equal((new B('hallo')).slice(0, 5).toString(), 'hallo')
   t.end()


### PR DESCRIPTION
Node.js's native Buffer module uses descending copying order in case that target buffer overlaps source buffer. This patch simulates the same behavior.

```
  var b = new Buffer('abcdefghij')
  b.copy(b, 3, 0, 7) // => 'abcabcdefg' but not 'abcabcabca'
```
