### PR TITLE
Fix call stack exceeded in #69

### DIFF
--- a/index.js
+++ b/index.js
@@ -622,6 +622,28 @@ function base64Slice (buf, start, end) {
   }
 }
 
+function decodeLargeCodePointsArray (array) {
+  var res = ''
+  var i
+  var end = array.length
+
+  for (i = 0; i < end; i++) {
+    res += String.fromCharCode(array[i])
+  }
+
+  return res
+}
+
+function decodeCodePointsArray (array) {
+  if (array.length < 0x10000) {
+    return String.fromCharCode.apply(String, array)
+  }
+  // Decode using string concatenation to avoid "call stack size exceeded".
+  // Based on http://stackoverflow.com/a/22747272/680742, the browser with
+  // the lowest limit is Chrome, with 0x10000 args.
+  return decodeLargeCodePointsArray(array)
+}
+
 function utf8Slice (buf, start, end) {
   end = Math.min(buf.length, end)
   var firstByte
@@ -700,7 +722,7 @@ function utf8Slice (buf, start, end) {
     res.push(codePoint)
   }
 
-  return String.fromCharCode.apply(String, res)
+  return decodeCodePointsArray(res)
 }
 
 function asciiSlice (buf, start, end) {


### PR DESCRIPTION
Based on [a JSPerf](http://jsperf.com/string-fromcharcode-apply-vs-string-fromcharcode-using-), calling `String.fromCharCode.apply(String, array)` is indeed faster than concatenating a string in a for-loop. But of course, even slow performance is preferable to a runtime error. :)

I haven't tested to find the optimal cutoff, but 0x10000 seems like a decent size for a "large" array. For comparison, we have a test in PouchDB that puts some large PNG data into localStorage as a binary string, and in buffer v3.4.0 it was taking ~45s to run, whereas using this fix we are down to 2.7s (and it is passing, unlike v3.4.1).