### PR TITLE
utf8Slice: don't replace the replacement character

### DIFF
--- a/index.js
+++ b/index.js
@@ -629,7 +629,7 @@ function utf8Slice (buf, start, end) {
   var i = start
   while (i < end) {
     var firstByte = buf[i]
-    var codePoint = 0xFFFD
+    var codePoint = null
     var bytesPerSequence = (firstByte > 0xEF) ? 4
       : (firstByte > 0xDF) ? 3
       : (firstByte > 0xBF) ? 2
@@ -676,8 +676,10 @@ function utf8Slice (buf, start, end) {
       }
     }
 
-    if (codePoint === 0xFFFD) {
-      // we generated an invalid codePoint so make sure to only advance by 1 byte
+    if (codePoint === null) {
+      // we did not generate a valid codePoint so insert a
+      // replacement char (U+FFFD) and advance only 1 byte
+      codePoint = 0xFFFD
       bytesPerSequence = 1
     } else if (codePoint > 0xFFFF) {
       // encode to utf16 (surrogate pair dance)

--- a/test/to-string.js
+++ b/test/to-string.js
@@ -223,3 +223,11 @@ test('utf8 replacement chars for anything in the surrogate pair range', function
   )
   t.end()
 })
+
+test('utf8 don\'t replace the replacement char', function (t) {
+  t.equal(
+    new B('\uFFFD').toString(),
+    '\uFFFD'
+  )
+  t.end()
+})


### PR DESCRIPTION
Noticed another inconsistency with node's Buffer - I hadn't thought about what would happen if there were already replacement chars in the utf8 we were converting!