### PR TITLE
fix overflow in older android

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -17,4 +17,4 @@ browsers:
   - name: ipad
     version: 5.1..latest
   - name: android
-    version: 5.0..latest
+    version: 4.0..latest

--- a/index.js
+++ b/index.js
@@ -1015,7 +1015,7 @@ Buffer.prototype.writeUInt8 = function writeUInt8 (value, offset, noAssert) {
   offset = offset | 0
   if (!noAssert) checkInt(this, value, offset, 1, 0xff, 0)
   if (!Buffer.TYPED_ARRAY_SUPPORT) value = Math.floor(value)
-  this[offset] = value
+  this[offset] = (value & 0xff)
   return offset + 1
 }
 
@@ -1032,7 +1032,7 @@ Buffer.prototype.writeUInt16LE = function writeUInt16LE (value, offset, noAssert
   offset = offset | 0
   if (!noAssert) checkInt(this, value, offset, 2, 0xffff, 0)
   if (Buffer.TYPED_ARRAY_SUPPORT) {
-    this[offset] = value
+    this[offset] = (value & 0xff)
     this[offset + 1] = (value >>> 8)
   } else {
     objectWriteUInt16(this, value, offset, true)
@@ -1046,7 +1046,7 @@ Buffer.prototype.writeUInt16BE = function writeUInt16BE (value, offset, noAssert
   if (!noAssert) checkInt(this, value, offset, 2, 0xffff, 0)
   if (Buffer.TYPED_ARRAY_SUPPORT) {
     this[offset] = (value >>> 8)
-    this[offset + 1] = value
+    this[offset + 1] = (value & 0xff)
   } else {
     objectWriteUInt16(this, value, offset, false)
   }
@@ -1068,7 +1068,7 @@ Buffer.prototype.writeUInt32LE = function writeUInt32LE (value, offset, noAssert
     this[offset + 3] = (value >>> 24)
     this[offset + 2] = (value >>> 16)
     this[offset + 1] = (value >>> 8)
-    this[offset] = value
+    this[offset] = (value & 0xff)
   } else {
     objectWriteUInt32(this, value, offset, true)
   }
@@ -1083,7 +1083,7 @@ Buffer.prototype.writeUInt32BE = function writeUInt32BE (value, offset, noAssert
     this[offset] = (value >>> 24)
     this[offset + 1] = (value >>> 16)
     this[offset + 2] = (value >>> 8)
-    this[offset + 3] = value
+    this[offset + 3] = (value & 0xff)
   } else {
     objectWriteUInt32(this, value, offset, false)
   }
@@ -1136,7 +1136,7 @@ Buffer.prototype.writeInt8 = function writeInt8 (value, offset, noAssert) {
   if (!noAssert) checkInt(this, value, offset, 1, 0x7f, -0x80)
   if (!Buffer.TYPED_ARRAY_SUPPORT) value = Math.floor(value)
   if (value < 0) value = 0xff + value + 1
-  this[offset] = value
+  this[offset] = (value & 0xff)
   return offset + 1
 }
 
@@ -1145,7 +1145,7 @@ Buffer.prototype.writeInt16LE = function writeInt16LE (value, offset, noAssert) 
   offset = offset | 0
   if (!noAssert) checkInt(this, value, offset, 2, 0x7fff, -0x8000)
   if (Buffer.TYPED_ARRAY_SUPPORT) {
-    this[offset] = value
+    this[offset] = (value & 0xff)
     this[offset + 1] = (value >>> 8)
   } else {
     objectWriteUInt16(this, value, offset, true)
@@ -1159,7 +1159,7 @@ Buffer.prototype.writeInt16BE = function writeInt16BE (value, offset, noAssert) 
   if (!noAssert) checkInt(this, value, offset, 2, 0x7fff, -0x8000)
   if (Buffer.TYPED_ARRAY_SUPPORT) {
     this[offset] = (value >>> 8)
-    this[offset + 1] = value
+    this[offset + 1] = (value & 0xff)
   } else {
     objectWriteUInt16(this, value, offset, false)
   }
@@ -1171,7 +1171,7 @@ Buffer.prototype.writeInt32LE = function writeInt32LE (value, offset, noAssert) 
   offset = offset | 0
   if (!noAssert) checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000)
   if (Buffer.TYPED_ARRAY_SUPPORT) {
-    this[offset] = value
+    this[offset] = (value & 0xff)
     this[offset + 1] = (value >>> 8)
     this[offset + 2] = (value >>> 16)
     this[offset + 3] = (value >>> 24)
@@ -1190,7 +1190,7 @@ Buffer.prototype.writeInt32BE = function writeInt32BE (value, offset, noAssert) 
     this[offset] = (value >>> 24)
     this[offset + 1] = (value >>> 16)
     this[offset + 2] = (value >>> 8)
-    this[offset + 3] = value
+    this[offset + 3] = (value & 0xff)
   } else {
     objectWriteUInt32(this, value, offset, false)
   }

--- a/test/write.js
+++ b/test/write.js
@@ -114,3 +114,18 @@ test('hex of write{Uint,Int}{8,16,32}{LE,BE} with overflow', function (t) {
   }
   t.end()
 })
+test('android issue', function (t) {
+  var nums = [-25589992, -633756690, -898146932]
+  var out = new Buffer(12)
+  out.fill(0)
+  out.writeInt32BE(nums[0], 0)
+  var newNum = out.readInt32BE(0)
+  t.equal(nums[0], newNum)
+  out.writeInt32BE(nums[1], 4)
+  newNum = out.readInt32BE(4)
+  t.equal(nums[1], newNum)
+  out.writeInt32BE(nums[2], 8)
+  newNum = out.readInt32BE(8)
+  t.equal(nums[2], newNum)
+  t.end()
+})

--- a/test/write.js
+++ b/test/write.js
@@ -114,9 +114,9 @@ test('hex of write{Uint,Int}{8,16,32}{LE,BE} with overflow', function (t) {
   }
   t.end()
 })
-test('android issue', function (t) {
+test('large values do not imporoperly roll over (ref #80)', function (t) {
   var nums = [-25589992, -633756690, -898146932]
-  var out = new Buffer(12)
+  var out = new B(12)
   out.fill(0)
   out.writeInt32BE(nums[0], 0)
   var newNum = out.readInt32BE(0)


### PR DESCRIPTION
if the tests take too long I can set up what we do for readable-stream where each browser is it's own saucelabs test