### PR TITLE
Use isarray instead of is-array

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@
 
 var base64 = require('base64-js')
 var ieee754 = require('ieee754')
-var isArray = require('is-array')
+var isArray = require('isarray')
 
 exports.Buffer = Buffer
 exports.SlowBuffer = SlowBuffer

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "base64-js": "0.0.8",
     "ieee754": "^1.1.4",
-    "is-array": "^1.0.1"
+    "isarray": "^0.0.1"
   },
   "devDependencies": {
     "benchmark": "^1.0.0",


### PR DESCRIPTION
Because isarray is 10x more popular.
They do exactly the same thing.
`npm i browserify` for example installs them both, with this change only one is installed.