### PR TITLE
Ensure ES2016 engines construct Uint8Array (not Buffer) from Buffer.p…

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,6 +217,11 @@ function fromJsonObject (that, object) {
 if (Buffer.TYPED_ARRAY_SUPPORT) {
   Buffer.prototype.__proto__ = Uint8Array.prototype
   Buffer.__proto__ = Uint8Array
+  if (typeof Symbol !== 'undefined' && Symbol.species &&
+      Buffer[Symbol.species] === Buffer) {
+    Object.defineProperty(Buffer, Symbol.species,
+                          { value: null, configurable: true })
+  }
 } else {
   // pre-set for values that may exist in the future
   Buffer.prototype.length = undefined


### PR DESCRIPTION
…rototype.slice

In the ES2016 draft specification, TypedArray methods like
%TypedArray%.prototype.subarray() call out to a constructor for the result
based on the receiver. Ordinarily, the constructor is instance.constructor,
but subclasses can override this using the Symbol.species property on the
constructor.

Buffer.prototype.slice calls out to %TypedArray%.prototype.subarray, which
calls this calculated constructor with three arguments. The argument pattern
doesn't correspond to a constructor for Buffer, so without setting
Symbol.species appropriately, the wrong kind of result is created.

This patch sets Buffer[Symbol.species] to Uint8Array when appropriate, to
address the issue.

This address issue https://github.com/nodejs/node/issues/4701