### PR TITLE
truncate toward infinity instead of raising an exception

### DIFF
--- a/index.js
+++ b/index.js
@@ -1193,7 +1193,6 @@ Buffer.prototype.writeInt32BE = function writeInt32BE (value, offset, noAssert) 
 }
 
 function checkIEEE754 (buf, value, offset, ext, max, min) {
-  if (value > max || value < min) throw new RangeError('value is out of bounds')
   if (offset + ext > buf.length) throw new RangeError('index out of range')
   if (offset < 0) throw new RangeError('index out of range')
 }

--- a/test/write_infinity.js
+++ b/test/write_infinity.js
@@ -1,0 +1,45 @@
+if (process.env.OBJECT_IMPL) global.TYPED_ARRAY_SUPPORT = false
+var B = require('../').Buffer
+var test = require('tape')
+
+test('write/read Infinity as a float', function (t) {
+  var buf = new B(4)
+  t.equal(buf.writeFloatBE(Infinity, 0), 4)
+  t.equal(buf.readFloatBE(0), Infinity)
+  t.end()
+})
+
+test('write/read -Infinity as a float', function (t) {
+  var buf = new B(4)
+  t.equal(buf.writeFloatBE(-Infinity, 0), 4)
+  t.equal(buf.readFloatBE(0), -Infinity)
+  t.end()
+})
+
+test('write/read Infinity as a double', function (t) {
+  var buf = new B(8)
+  t.equal(buf.writeDoubleBE(Infinity, 0), 8)
+  t.equal(buf.readDoubleBE(0), Infinity)
+  t.end()
+})
+
+test('write/read -Infinity as a double', function (t) {
+  var buf = new B(8)
+  t.equal(buf.writeDoubleBE(-Infinity, 0), 8)
+  t.equal(buf.readDoubleBE(0), -Infinity)
+  t.end()
+})
+
+test('write/read float greater than max', function (t) {
+  var buf = new B(4)
+  t.equal(buf.writeFloatBE(4e38, 0), 4)
+  t.equal(buf.readFloatBE(0), Infinity)
+  t.end()
+})
+
+test('write/read float less than min', function (t) {
+  var buf = new B(4)
+  t.equal(buf.writeFloatBE(-4e40, 0), 4)
+  t.equal(buf.readFloatBE(0), -Infinity)
+  t.end()
+})


### PR DESCRIPTION
fix for #99 to match node behavior to truncate towards ±Infinity instead of raising an exception