### PR TITLE
Call correct set method on Buffer.copy()

### DIFF
--- a/index.js
+++ b/index.js
@@ -1278,7 +1278,7 @@ Buffer.prototype.copy = function copy (target, targetStart, start, end) {
       target[i + targetStart] = this[i + start]
     }
   } else {
-    target._set(this.subarray(start, start + len), targetStart)
+    target.set(this.subarray(start, start + len), targetStart)
   }
 
   return len

--- a/index.js
+++ b/index.js
@@ -1278,7 +1278,11 @@ Buffer.prototype.copy = function copy (target, targetStart, start, end) {
       target[i + targetStart] = this[i + start]
     }
   } else {
-    target.set(this.subarray(start, start + len), targetStart)
+    Uint8Array.prototype.set.call(
+      target,
+      this.subarray(start, start + len),
+      targetStart
+    )
   }
 
   return len


### PR DESCRIPTION
This is a fix from the 3.6.0 tag (no branch).

Current stable Webpack (v1.13.0) depends on node-libs-browser <= 0.6.0 which in turn depends on buffer ^3.0.3 which pulls in v3.6.0 which still has this bug.