### PR TITLE
re #121: IE10-on-IE11 fails the augmentation

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ exports.kMaxLength = kMaxLength()
 function typedArraySupport () {
   try {
     var arr = new Uint8Array(1)
-    arr.foo = function () { return 42 }
+    arr.__proto__ = {__proto__: Uint8Array.prototype, foo: function () { return 42 }}
     return arr.foo() === 42 && // typed array instances can be augmented
         typeof arr.subarray === 'function' && // chrome 9-10 lack `subarray`
         arr.subarray(1, 1).byteLength === 0 // ie10 has broken `subarray`


### PR DESCRIPTION
This patch fixes the problem found on IE10 mode of IE11 developer tools.
It follows the new way to augment Uint8Array instances on typedArraySupport method.
