### PR TITLE
Update node.js tests and fix the bugs it caught

### DIFF
--- a/bin/download-node-tests.js
+++ b/bin/download-node-tests.js
@@ -75,7 +75,7 @@ function testfixer (filename) {
     line = line.replace(/(const|let) /g, 'var ')
 
     // make `var common = require('common')` work
-    line = line.replace(/(var common = require.*)/g, 'var common = {};')
+    line = line.replace(/(var common = require.*)/g, 'var common = { skip: function () {} };')
 
     // make `require('../common')` work
     line = line.replace(/require\('\.\.\/common'\);/g, '')

--- a/bin/download-node-tests.js
+++ b/bin/download-node-tests.js
@@ -65,8 +65,7 @@ function testfixer (filename) {
 
     if (firstline) {
       // require buffer explicitly
-      var preamble = 'var Buffer = require(\'../../\').Buffer;\n' +
-        'if (!Buffer.TYPED_ARRAY_SUPPORT) return;'
+      var preamble = 'var Buffer = require(\'../../\').Buffer;\n'
       if (/use strict/.test(line)) line += '\n' + preamble
       else line + preamble + '\n' + line
       firstline = false

--- a/bin/download-node-tests.js
+++ b/bin/download-node-tests.js
@@ -66,7 +66,7 @@ function testfixer (filename) {
     if (firstline) {
       // require buffer explicitly
       var preamble = 'var Buffer = require(\'../../\').Buffer;\n' +
-        'if (Buffer.TYPED_ARRAY_SUPPORT) return;'
+        'if (!Buffer.TYPED_ARRAY_SUPPORT) return;'
       if (/use strict/.test(line)) line += '\n' + preamble
       else line + preamble + '\n' + line
       firstline = false

--- a/index.js
+++ b/index.js
@@ -228,7 +228,12 @@ function fromString (that, string, encoding) {
   var length = byteLength(string, encoding) | 0
   that = createBuffer(that, length)
 
-  that.write(string, encoding)
+  var actual = that.write(string, encoding)
+
+  if (actual !== length) {
+    that = that.slice(0, actual)
+  }
+
   return that
 }
 

--- a/index.js
+++ b/index.js
@@ -351,6 +351,7 @@ Buffer.isEncoding = function isEncoding (encoding) {
     case 'utf8':
     case 'utf-8':
     case 'ascii':
+    case 'latin1':
     case 'binary':
     case 'base64':
     case 'ucs2':
@@ -413,6 +414,7 @@ function byteLength (string, encoding) {
   for (;;) {
     switch (encoding) {
       case 'ascii':
+      case 'latin1':
       case 'binary':
         return len
       case 'utf8':
@@ -486,8 +488,9 @@ function slowToString (encoding, start, end) {
       case 'ascii':
         return asciiSlice(this, start, end)
 
+      case 'latin1':
       case 'binary':
-        return binarySlice(this, start, end)
+        return latin1Slice(this, start, end)
 
       case 'base64':
         return base64Slice(this, start, end)
@@ -753,7 +756,7 @@ function asciiWrite (buf, string, offset, length) {
   return blitBuffer(asciiToBytes(string), buf, offset, length)
 }
 
-function binaryWrite (buf, string, offset, length) {
+function latin1Write (buf, string, offset, length) {
   return asciiWrite(buf, string, offset, length)
 }
 
@@ -815,8 +818,9 @@ Buffer.prototype.write = function write (string, offset, length, encoding) {
       case 'ascii':
         return asciiWrite(this, string, offset, length)
 
+      case 'latin1':
       case 'binary':
-        return binaryWrite(this, string, offset, length)
+        return latin1Write(this, string, offset, length)
 
       case 'base64':
         // Warning: maxLength not taken into account in base64Write
@@ -957,7 +961,7 @@ function asciiSlice (buf, start, end) {
   return ret
 }
 
-function binarySlice (buf, start, end) {
+function latin1Slice (buf, start, end) {
   var ret = ''
   end = Math.min(buf.length, end)
 

--- a/index.js
+++ b/index.js
@@ -708,6 +708,9 @@ Buffer.prototype.indexOf = function indexOf (val, byteOffset, encoding) {
     return arrayIndexOf(this, val, byteOffset, encoding)
   }
   if (typeof val === 'number') {
+    // Numbers will be interpreted as unsigned 8-bit integer values between
+    // `0` and `255`.
+    val &= 0xFF
     if (Buffer.TYPED_ARRAY_SUPPORT && Uint8Array.prototype.indexOf === 'function') {
       return Uint8Array.prototype.indexOf.call(this, val, byteOffset)
     }
@@ -735,7 +738,7 @@ function hexWrite (buf, string, offset, length) {
 
   // must be an even number of digits
   var strLen = string.length
-  if (strLen % 2 !== 0) throw new Error('Invalid hex string')
+  if (strLen % 2 !== 0) throw new TypeError('Invalid hex string')
 
   if (length > strLen / 2) {
     length = strLen / 2

--- a/index.js
+++ b/index.js
@@ -231,6 +231,9 @@ function fromString (that, string, encoding) {
   var actual = that.write(string, encoding)
 
   if (actual !== length) {
+    // Writing a hex string, for example, that contains invalid characters will
+    // cause everything after the first invalid character to be ignored. (e.g.
+    // 'abxxcd' will be treated as 'ab')
     that = that.slice(0, actual)
   }
 

--- a/index.js
+++ b/index.js
@@ -353,7 +353,6 @@ Buffer.isEncoding = function isEncoding (encoding) {
     case 'ascii':
     case 'binary':
     case 'base64':
-    case 'raw':
     case 'ucs2':
     case 'ucs-2':
     case 'utf16le':
@@ -415,8 +414,6 @@ function byteLength (string, encoding) {
     switch (encoding) {
       case 'ascii':
       case 'binary':
-      case 'raw':
-      case 'raws':
         return len
       case 'utf8':
       case 'utf-8':

--- a/index.js
+++ b/index.js
@@ -725,6 +725,10 @@ Buffer.prototype.indexOf = function indexOf (val, byteOffset, encoding) {
   throw new TypeError('val must be string, number or Buffer')
 }
 
+Buffer.prototype.lastIndexOf = function () {
+  throw new Error('Not implemented yet. PR welcome! https://github.com/feross/buffer/issues/114')
+}
+
 Buffer.prototype.includes = function includes (val, byteOffset, encoding) {
   return this.indexOf(val, byteOffset, encoding) !== -1
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "benchmark": "^2.0.0",
     "browserify": "^13.0.0",
     "concat-stream": "^1.4.7",
-    "hyperquest": "^1.0.1",
+    "hyperquest": "^2.0.0",
     "is-buffer": "^1.1.1",
     "is-nan": "^1.0.1",
     "split": "^1.0.0",

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (Buffer.TYPED_ARRAY_SUPPORT) return;
+if (!Buffer.TYPED_ARRAY_SUPPORT) return;
 var common = {};
 var assert = require('assert');
 

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -1,7 +1,7 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (!Buffer.TYPED_ARRAY_SUPPORT) return;
-var common = {};
+
+var common = { skip: function () {} };
 var assert = require('assert');
 
 var Buffer = require('../../').Buffer;
@@ -237,7 +237,7 @@ assert.strictEqual('Unknown encoding: invalid', caught_error.message);
 // try to create 0-length buffers
 Buffer.from('');
 Buffer.from('', 'ascii');
-Buffer.from('', 'binary');
+Buffer.from('', 'latin1');
 Buffer.alloc(0);
 Buffer.allocUnsafe(0);
 
@@ -691,7 +691,7 @@ assert.equal(dot.toString('base64'), '//4uAA==');
   for (var i = 0; i < segments.length; ++i) {
     pos += b.write(segments[i], pos, 'base64');
   }
-  assert.equal(b.toString('binary', 0, pos), 'Madness?! This is node.js!');
+  assert.equal(b.toString('latin1', 0, pos), 'Madness?! This is node.js!');
 }
 
 // Regression test for https://github.com/nodejs/node/issues/3496.
@@ -847,13 +847,13 @@ assert.equal(0, Buffer.from('hello').slice(0, 0).length);
   // Binary encoding should write only one byte per character.
   var b = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
   var s = String.fromCharCode(0xffff);
-  b.write(s, 0, 'binary');
+  b.write(s, 0, 'latin1');
   assert.equal(0xff, b[0]);
   assert.equal(0xad, b[1]);
   assert.equal(0xbe, b[2]);
   assert.equal(0xef, b[3]);
   s = String.fromCharCode(0xaaee);
-  b.write(s, 0, 'binary');
+  b.write(s, 0, 'latin1');
   assert.equal(0xee, b[0]);
   assert.equal(0xad, b[1]);
   assert.equal(0xbe, b[2]);
@@ -971,7 +971,7 @@ assert.equal(0, Buffer.from('hello').slice(0, 0).length);
   // test for buffer overrun
   var buf = Buffer.from([0, 0, 0, 0, 0]); // length: 5
   var sub = buf.slice(0, 4);         // length: 4
-  written = sub.write('12345', 'binary');
+  written = sub.write('12345', 'latin1');
   assert.equal(written, 4);
   assert.equal(buf[4], 0);
 }
@@ -994,7 +994,7 @@ assert.equal(Buffer.from('99').length, 2);
 assert.equal(Buffer.from('13.37').length, 5);
 
 // Ensure that the length argument is respected.
-'ascii utf8 hex base64 binary'.split(' ').forEach(function(enc) {
+'ascii utf8 hex base64 latin1'.split(' ').forEach(function(enc) {
   assert.equal(Buffer.allocUnsafe(1).write('aaaaaa', 0, 1, enc), 1);
 });
 
@@ -1013,6 +1013,7 @@ Buffer.from(Buffer.allocUnsafe(0), 0, 0);
   'utf8',
   'utf-8',
   'ascii',
+  'latin1',
   'binary',
   'base64',
   'ucs2',
@@ -1025,34 +1026,42 @@ Buffer.from(Buffer.allocUnsafe(0), 0, 0);
 [ 'utf9',
   'utf-7',
   'Unicode-FTW',
-  'new gnu gun'  ].forEach(function(enc) {
+  'new gnu gun',
+  false,
+  NaN,
+  {},
+  Infinity,
+  [],
+  1,
+  0,
+  -1 ].forEach(function(enc) {
     assert.equal(Buffer.isEncoding(enc), false);
   });
 
 
 // GH-5110
-(function() {
+{
   var buffer = Buffer.from('test');
   var string = JSON.stringify(buffer);
 
-  assert.equal(string, '{"type":"Buffer","data":[116,101,115,116]}');
+  assert.strictEqual(string, '{"type":"Buffer","data":[116,101,115,116]}');
 
   assert.deepStrictEqual(buffer, JSON.parse(string, function(key, value) {
     return value && value.type === 'Buffer'
       ? Buffer.from(value.data)
       : value;
   }));
-})();
+}
 
 // issue GH-7849
-(function() {
+{
   var buf = Buffer.from('test');
   var json = JSON.stringify(buf);
   var obj = JSON.parse(json);
   var copy = Buffer.from(obj);
 
   assert(buf.equals(copy));
-})();
+}
 
 // issue GH-4331
 assert.throws(function() {
@@ -1158,29 +1167,29 @@ assert.throws(function() {
 });
 
 // test for common read(U)IntLE/BE
-(function() {
+{
   var buf = Buffer.from([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
 
-  assert.equal(buf.readUIntLE(0, 1), 0x01);
-  assert.equal(buf.readUIntBE(0, 1), 0x01);
-  assert.equal(buf.readUIntLE(0, 3), 0x030201);
-  assert.equal(buf.readUIntBE(0, 3), 0x010203);
-  assert.equal(buf.readUIntLE(0, 5), 0x0504030201);
-  assert.equal(buf.readUIntBE(0, 5), 0x0102030405);
-  assert.equal(buf.readUIntLE(0, 6), 0x060504030201);
-  assert.equal(buf.readUIntBE(0, 6), 0x010203040506);
-  assert.equal(buf.readIntLE(0, 1), 0x01);
-  assert.equal(buf.readIntBE(0, 1), 0x01);
-  assert.equal(buf.readIntLE(0, 3), 0x030201);
-  assert.equal(buf.readIntBE(0, 3), 0x010203);
-  assert.equal(buf.readIntLE(0, 5), 0x0504030201);
-  assert.equal(buf.readIntBE(0, 5), 0x0102030405);
-  assert.equal(buf.readIntLE(0, 6), 0x060504030201);
-  assert.equal(buf.readIntBE(0, 6), 0x010203040506);
-})();
+  assert.strictEqual(buf.readUIntLE(0, 1), 0x01);
+  assert.strictEqual(buf.readUIntBE(0, 1), 0x01);
+  assert.strictEqual(buf.readUIntLE(0, 3), 0x030201);
+  assert.strictEqual(buf.readUIntBE(0, 3), 0x010203);
+  assert.strictEqual(buf.readUIntLE(0, 5), 0x0504030201);
+  assert.strictEqual(buf.readUIntBE(0, 5), 0x0102030405);
+  assert.strictEqual(buf.readUIntLE(0, 6), 0x060504030201);
+  assert.strictEqual(buf.readUIntBE(0, 6), 0x010203040506);
+  assert.strictEqual(buf.readIntLE(0, 1), 0x01);
+  assert.strictEqual(buf.readIntBE(0, 1), 0x01);
+  assert.strictEqual(buf.readIntLE(0, 3), 0x030201);
+  assert.strictEqual(buf.readIntBE(0, 3), 0x010203);
+  assert.strictEqual(buf.readIntLE(0, 5), 0x0504030201);
+  assert.strictEqual(buf.readIntBE(0, 5), 0x0102030405);
+  assert.strictEqual(buf.readIntLE(0, 6), 0x060504030201);
+  assert.strictEqual(buf.readIntBE(0, 6), 0x010203040506);
+}
 
 // test for common write(U)IntLE/BE
-(function() {
+{
   var buf = Buffer.allocUnsafe(3);
   buf.writeUIntLE(0x123456, 0, 3);
   assert.deepStrictEqual(buf.toJSON().data, [0x56, 0x34, 0x12]);
@@ -1270,10 +1279,10 @@ assert.throws(function() {
   buf.writeIntBE(-0x0012000000, 0, 5);
   assert.deepStrictEqual(buf.toJSON().data, [0xff, 0xee, 0x00, 0x00, 0x00]);
   assert.equal(buf.readIntBE(0, 5), -0x0012000000);
-})();
+}
 
 // test Buffer slice
-(function() {
+{
   var buf = Buffer.from('0123456789');
   assert.equal(buf.slice(-10, 10), '0123456789');
   assert.equal(buf.slice(-20, 10), '0123456789');
@@ -1321,7 +1330,7 @@ assert.throws(function() {
   // try to slice a zero length Buffer
   // see https://github.com/joyent/node/issues/5881
   Buffer.alloc(0).slice(0, 1);
-})();
+}
 
 // Regression test for #5482: should throw but not assert in C++ land.
 assert.throws(function() {
@@ -1330,20 +1339,20 @@ assert.throws(function() {
 
 // Regression test for #6111. Constructing a buffer from another buffer
 // should a) work, and b) not corrupt the source buffer.
-(function() {
+{
   var a = [0];
   for (var i = 0; i < 7; ++i) a = a.concat(a);
   a = a.map(function(_, i) { return i; });
   var b = Buffer.from(a);
   var c = Buffer.from(b);
-  assert.equal(b.length, a.length);
-  assert.equal(c.length, a.length);
+  assert.strictEqual(b.length, a.length);
+  assert.strictEqual(c.length, a.length);
   for (var i = 0, k = a.length; i < k; ++i) {
-    assert.equal(a[i], i);
-    assert.equal(b[i], i);
-    assert.equal(c[i], i);
+    assert.strictEqual(a[i], i);
+    assert.strictEqual(b[i], i);
+    assert.strictEqual(c[i], i);
   }
-})();
+}
 
 
 assert.throws(function() {
@@ -1366,7 +1375,7 @@ if (common.hasCrypto) {
     crypto.createHash('sha1').update(b2).digest('hex')
   );
 } else {
-//   console.log('1..0 # Skipped: missing crypto');
+  common.skip('missing crypto');
 }
 
 // Test Compare
@@ -1455,9 +1464,21 @@ assert.throws(function() {
   Buffer.from(new ArrayBuffer(0), -1 >>> 0);
 }, /RangeError: 'offset' is out of bounds/);
 
+// ParseArrayIndex() should reject values that don't fit in a 32 bits size_t.
+assert.throws(() => {
+  var a = Buffer(1).fill(0);
+  var b = Buffer(1).fill(0);
+  a.copy(b, 0, 0x100000000, 0x100000001);
+}), /out of range index/;
+
 // Unpooled buffer (replaces SlowBuffer)
 var ubuf = Buffer.allocUnsafeSlow(10);
 assert(ubuf);
 assert(ubuf.buffer);
 assert.equal(ubuf.buffer.byteLength, 10);
+
+// Regression test
+assert.doesNotThrow(() => {
+  Buffer.from(new ArrayBuffer());
+});
 

--- a/test/node/test-buffer-arraybuffer.js
+++ b/test/node/test-buffer-arraybuffer.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (!Buffer.TYPED_ARRAY_SUPPORT) return;
+
 
 
 var assert = require('assert');

--- a/test/node/test-buffer-arraybuffer.js
+++ b/test/node/test-buffer-arraybuffer.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (Buffer.TYPED_ARRAY_SUPPORT) return;
+if (!Buffer.TYPED_ARRAY_SUPPORT) return;
 
 
 var assert = require('assert');

--- a/test/node/test-buffer-ascii.js
+++ b/test/node/test-buffer-ascii.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (!Buffer.TYPED_ARRAY_SUPPORT) return;
+
 
 var assert = require('assert');
 

--- a/test/node/test-buffer-ascii.js
+++ b/test/node/test-buffer-ascii.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (Buffer.TYPED_ARRAY_SUPPORT) return;
+if (!Buffer.TYPED_ARRAY_SUPPORT) return;
 
 var assert = require('assert');
 

--- a/test/node/test-buffer-bad-overload.js
+++ b/test/node/test-buffer-bad-overload.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (!Buffer.TYPED_ARRAY_SUPPORT) return;
+
 
 var assert = require('assert');
 

--- a/test/node/test-buffer-bad-overload.js
+++ b/test/node/test-buffer-bad-overload.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (Buffer.TYPED_ARRAY_SUPPORT) return;
+if (!Buffer.TYPED_ARRAY_SUPPORT) return;
 
 var assert = require('assert');
 

--- a/test/node/test-buffer-badhex.js
+++ b/test/node/test-buffer-badhex.js
@@ -1,0 +1,46 @@
+'use strict';
+var Buffer = require('../../').Buffer;
+
+
+var assert = require('assert');
+var Buffer = require('../../').Buffer;
+
+// Test hex strings and bad hex strings
+{
+  var buf1 = Buffer.alloc(4);
+  assert.strictEqual(buf1.length, 4);
+  assert.deepStrictEqual(buf1, new Buffer([0, 0, 0, 0]));
+  assert.strictEqual(buf1.write('abcdxx', 0, 'hex'), 2);
+  assert.deepStrictEqual(buf1, new Buffer([0xab, 0xcd, 0x00, 0x00]));
+  assert.strictEqual(buf1.toString('hex'), 'abcd0000');
+  assert.strictEqual(buf1.write('abcdef01', 0, 'hex'), 4);
+  assert.deepStrictEqual(buf1, new Buffer([0xab, 0xcd, 0xef, 0x01]));
+  assert.strictEqual(buf1.toString('hex'), 'abcdef01');
+
+  var buf2 = Buffer.from(buf1.toString('hex'), 'hex');
+  assert.strictEqual(buf1.toString('hex'), buf2.toString('hex'));
+
+  var buf3 = Buffer.alloc(5);
+  assert.strictEqual(buf3.write('abcdxx', 1, 'hex'), 2);
+  assert.strictEqual(buf3.toString('hex'), '00abcd0000');
+
+  var buf4 = Buffer.alloc(4);
+  assert.deepStrictEqual(buf4, new Buffer([0, 0, 0, 0]));
+  assert.strictEqual(buf4.write('xxabcd', 0, 'hex'), 0);
+  assert.deepStrictEqual(buf4, new Buffer([0, 0, 0, 0]));
+  assert.strictEqual(buf4.write('xxab', 1, 'hex'), 0);
+  assert.deepStrictEqual(buf4, new Buffer([0, 0, 0, 0]));
+  assert.strictEqual(buf4.write('cdxxab', 0, 'hex'), 1);
+  assert.deepStrictEqual(buf4, new Buffer([0xcd, 0, 0, 0]));
+
+  var buf5 = Buffer.alloc(256);
+  for (var i = 0; i < 256; i++)
+    buf5[i] = i;
+
+  var hex = buf5.toString('hex');
+  assert.deepStrictEqual(Buffer.from(hex, 'hex'), buf5);
+
+  var badHex = hex.slice(0, 256) + 'xx' + hex.slice(256, 510);
+  assert.deepStrictEqual(Buffer.from(badHex, 'hex'), buf5.slice(0, 128));
+}
+

--- a/test/node/test-buffer-badhex.js
+++ b/test/node/test-buffer-badhex.js
@@ -5,6 +5,47 @@ var Buffer = require('../../').Buffer;
 var assert = require('assert');
 var Buffer = require('../../').Buffer;
 
+/**
+ * TEMPORARY HACK UNTIL THIS ASSERT BUG IS FIXED IN NODE CORE
+ * https://github.com/nodejs/node/issues/8001
+ */
+var pToString = function (obj) { return Object.prototype.toString.call(obj) }
+var _deepStrictEqual = assert.deepStrictEqual
+assert.deepStrictEqual = function (actual, expected, msg) {
+  if (typeof ArrayBuffer !== 'undefined' && ArrayBuffer.isView(actual) &&
+      ArrayBuffer.isView(expected) && !require('buffer').Buffer.isBuffer(actual) &&
+      !require('buffer').Buffer.isBuffer(expected) && pToString(actual) === pToString(expected) &&
+      !(actual instanceof Float32Array || actual instanceof Float64Array)) {
+    assert.equal(Buffer.compare(Buffer.from(actual.buffer,
+                                            actual.byteOffset,
+                                            actual.byteLength),
+                             Buffer.from(expected.buffer,
+                                         expected.byteOffset,
+                                         expected.byteLength)), 0);
+  } else {
+    _deepStrictEqual.call(assert, actual, expected, msg)
+  }
+}
+var _deepEqual = assert.deepEqual
+assert.deepEqual = function (actual, expected, msg) {
+  if (typeof ArrayBuffer !== 'undefined' && ArrayBuffer.isView(actual) &&
+      ArrayBuffer.isView(expected) && !require('buffer').Buffer.isBuffer(actual) &&
+      !require('buffer').Buffer.isBuffer(expected) && pToString(actual) === pToString(expected) &&
+      !(actual instanceof Float32Array || actual instanceof Float64Array)) {
+    assert.ok(Buffer.compare(Buffer.from(actual.buffer,
+                                         actual.byteOffset,
+                                         actual.byteLength),
+                             Buffer.from(expected.buffer,
+                                         expected.byteOffset,
+                                         expected.byteLength)) === 0);
+  } else {
+    _deepEqual.call(assert, actual, expected, msg)
+  }
+}
+/**
+ * END HACK
+ */
+
 // Test hex strings and bad hex strings
 {
   var buf1 = Buffer.alloc(4);

--- a/test/node/test-buffer-bytelength.js
+++ b/test/node/test-buffer-bytelength.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (!Buffer.TYPED_ARRAY_SUPPORT) return;
+
 
 
 var assert = require('assert');
@@ -8,9 +8,9 @@ var Buffer = require('../../').Buffer;
 var SlowBuffer = require('../../').SlowBuffer;
 
 // coerce values to string
-assert.equal(Buffer.byteLength(32, 'binary'), 2);
+assert.equal(Buffer.byteLength(32, 'latin1'), 2);
 assert.equal(Buffer.byteLength(NaN, 'utf8'), 3);
-assert.equal(Buffer.byteLength({}, 'binary'), 15);
+assert.equal(Buffer.byteLength({}, 'latin1'), 15);
 assert.equal(Buffer.byteLength(), 9);
 
 var buff = new Buffer(10);
@@ -82,6 +82,7 @@ assert.equal(Buffer.byteLength('aaaa==', 'base64'), 3);
 assert.equal(Buffer.byteLength('Il était tué'), 14);
 assert.equal(Buffer.byteLength('Il était tué', 'utf8'), 14);
 assert.equal(Buffer.byteLength('Il était tué', 'ascii'), 12);
+assert.equal(Buffer.byteLength('Il était tué', 'latin1'), 12);
 assert.equal(Buffer.byteLength('Il était tué', 'binary'), 12);
 ['ucs2', 'ucs-2', 'utf16le', 'utf-16le'].forEach(function(encoding) {
   assert.equal(24, Buffer.byteLength('Il était tué', encoding));

--- a/test/node/test-buffer-bytelength.js
+++ b/test/node/test-buffer-bytelength.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (Buffer.TYPED_ARRAY_SUPPORT) return;
+if (!Buffer.TYPED_ARRAY_SUPPORT) return;
 
 
 var assert = require('assert');

--- a/test/node/test-buffer-compare-offset.js
+++ b/test/node/test-buffer-compare-offset.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (!Buffer.TYPED_ARRAY_SUPPORT) return;
+
 
 
 var assert = require('assert');

--- a/test/node/test-buffer-compare-offset.js
+++ b/test/node/test-buffer-compare-offset.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (Buffer.TYPED_ARRAY_SUPPORT) return;
+if (!Buffer.TYPED_ARRAY_SUPPORT) return;
 
 
 var assert = require('assert');

--- a/test/node/test-buffer-concat.js
+++ b/test/node/test-buffer-concat.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (Buffer.TYPED_ARRAY_SUPPORT) return;
+if (!Buffer.TYPED_ARRAY_SUPPORT) return;
 
 var assert = require('assert');
 

--- a/test/node/test-buffer-concat.js
+++ b/test/node/test-buffer-concat.js
@@ -1,11 +1,11 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (!Buffer.TYPED_ARRAY_SUPPORT) return;
+
 
 var assert = require('assert');
 
 var zero = [];
-var one  = [ Buffer.from('asdf') ];
+var one = [ Buffer.from('asdf') ];
 var long = [];
 for (var i = 0; i < 10; i++) long.push(Buffer.from('asdf'));
 

--- a/test/node/test-buffer-fill.js
+++ b/test/node/test-buffer-fill.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (!Buffer.TYPED_ARRAY_SUPPORT) return;
+
 
 
 var assert = require('assert');
@@ -73,6 +73,27 @@ testBufs('\u0222aa', 8, 1, 'binary');
 testBufs('a\u0234b\u0235c\u0236', 4, -1, 'binary');
 testBufs('a\u0234b\u0235c\u0236', 4, 1, 'binary');
 testBufs('a\u0234b\u0235c\u0236', 12, 1, 'binary');
+
+
+// LATIN1
+testBufs('abc', 'latin1');
+testBufs('\u0222aa', 'latin1');
+testBufs('a\u0234b\u0235c\u0236', 'latin1');
+testBufs('abc', 4, 'latin1');
+testBufs('abc', 5, 'latin1');
+testBufs('abc', SIZE, 'latin1');
+testBufs('\u0222aa', 2, 'latin1');
+testBufs('\u0222aa', 8, 'latin1');
+testBufs('a\u0234b\u0235c\u0236', 4, 'latin1');
+testBufs('a\u0234b\u0235c\u0236', 12, 'latin1');
+testBufs('abc', 4, -1, 'latin1');
+testBufs('abc', 4, 1, 'latin1');
+testBufs('abc', 5, 1, 'latin1');
+testBufs('\u0222aa', 2, -1, 'latin1');
+testBufs('\u0222aa', 8, 1, 'latin1');
+testBufs('a\u0234b\u0235c\u0236', 4, -1, 'latin1');
+testBufs('a\u0234b\u0235c\u0236', 4, 1, 'latin1');
+testBufs('a\u0234b\u0235c\u0236', 12, 1, 'latin1');
 
 
 // UCS2

--- a/test/node/test-buffer-fill.js
+++ b/test/node/test-buffer-fill.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (Buffer.TYPED_ARRAY_SUPPORT) return;
+if (!Buffer.TYPED_ARRAY_SUPPORT) return;
 
 
 var assert = require('assert');

--- a/test/node/test-buffer-includes.js
+++ b/test/node/test-buffer-includes.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (!Buffer.TYPED_ARRAY_SUPPORT) return;
+
 
 var assert = require('assert');
 
@@ -81,36 +81,64 @@ assert(!b.includes(Buffer.from('f'), 6));
 assert(!Buffer.from('ff').includes(Buffer.from('f'), 1, 'ucs2'));
 
 // test hex encoding
-assert(
-    Buffer.from(b.toString('hex'), 'hex')
-    .includes('64', 0, 'hex'));
-assert(
-    Buffer.from(b.toString('hex'), 'hex')
-    .includes(Buffer.from('64', 'hex'), 0, 'hex'));
+assert.strictEqual(
+  Buffer.from(b.toString('hex'), 'hex')
+    .includes('64', 0, 'hex'),
+  true
+);
+assert.strictEqual(
+  Buffer.from(b.toString('hex'), 'hex')
+    .includes(Buffer.from('64', 'hex'), 0, 'hex'),
+  true
+);
 
 // test base64 encoding
-assert(
-    Buffer.from(b.toString('base64'), 'base64')
-    .includes('ZA==', 0, 'base64'));
-assert(
-    Buffer.from(b.toString('base64'), 'base64')
-    .includes(Buffer.from('ZA==', 'base64'), 0, 'base64'));
+assert.strictEqual(
+  Buffer.from(b.toString('base64'), 'base64')
+    .includes('ZA==', 0, 'base64'),
+  true
+);
+assert.strictEqual(
+  Buffer.from(b.toString('base64'), 'base64')
+    .includes(Buffer.from('ZA==', 'base64'), 0, 'base64'),
+  true
+);
 
 // test ascii encoding
-assert(
-    Buffer.from(b.toString('ascii'), 'ascii')
-    .includes('d', 0, 'ascii'));
-assert(
-    Buffer.from(b.toString('ascii'), 'ascii')
-    .includes(Buffer.from('d', 'ascii'), 0, 'ascii'));
+assert.strictEqual(
+  Buffer.from(b.toString('ascii'), 'ascii')
+    .includes('d', 0, 'ascii'),
+  true
+);
+assert.strictEqual(
+  Buffer.from(b.toString('ascii'), 'ascii')
+    .includes(Buffer.from('d', 'ascii'), 0, 'ascii'),
+  true
+);
+
+// test latin1 encoding
+assert.strictEqual(
+  Buffer.from(b.toString('latin1'), 'latin1')
+    .includes('d', 0, 'latin1'),
+  true
+);
+assert.strictEqual(
+  Buffer.from(b.toString('latin1'), 'latin1')
+    .includes(Buffer.from('d', 'latin1'), 0, 'latin1'),
+  true
+);
 
 // test binary encoding
-assert(
-    Buffer.from(b.toString('binary'), 'binary')
-    .includes('d', 0, 'binary'));
-assert(
-    Buffer.from(b.toString('binary'), 'binary')
-    .includes(Buffer.from('d', 'binary'), 0, 'binary'));
+assert.strictEqual(
+  Buffer.from(b.toString('binary'), 'binary')
+    .includes('d', 0, 'binary'),
+  true
+);
+assert.strictEqual(
+  Buffer.from(b.toString('binary'), 'binary')
+    .includes(Buffer.from('d', 'binary'), 0, 'binary'),
+  true
+);
 
 
 // test usc2 encoding
@@ -166,7 +194,7 @@ assert(!mixedByteStringUtf8.includes('\u0396'));
 // Long string that isn't a simple repeat of a shorter string.
 var longString = 'A';
 for (var i = 66; i < 76; i++) {  // from 'B' to 'K'
-  longString =  longString + String.fromCharCode(i) + longString;
+  longString = longString + String.fromCharCode(i) + longString;
 }
 
 var longBufferString = Buffer.from(longString);
@@ -258,4 +286,20 @@ assert.throws(function() {
 assert.throws(function() {
   b.includes([]);
 });
+
+// test truncation of Number arguments to uint8
+{
+  var buf = Buffer.from('this is a test');
+  assert.ok(buf.includes(0x6973));
+  assert.ok(buf.includes(0x697320));
+  assert.ok(buf.includes(0x69732069));
+  assert.ok(buf.includes(0x697374657374));
+  assert.ok(buf.includes(0x69737374));
+  assert.ok(buf.includes(0x69737465));
+  assert.ok(buf.includes(0x69737465));
+  assert.ok(buf.includes(-140));
+  assert.ok(buf.includes(-152));
+  assert.ok(!buf.includes(0xff));
+  assert.ok(!buf.includes(0xffff));
+}
 

--- a/test/node/test-buffer-includes.js
+++ b/test/node/test-buffer-includes.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (Buffer.TYPED_ARRAY_SUPPORT) return;
+if (!Buffer.TYPED_ARRAY_SUPPORT) return;
 
 var assert = require('assert');
 

--- a/test/node/test-buffer-indexof.js
+++ b/test/node/test-buffer-indexof.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (!Buffer.TYPED_ARRAY_SUPPORT) return;
+
 
 var assert = require('assert');
 
@@ -81,45 +81,94 @@ assert.equal(b.indexOf(Buffer.from('f'), 6), -1);
 assert.equal(Buffer.from('ff').indexOf(Buffer.from('f'), 1, 'ucs2'), -1);
 
 // test hex encoding
-assert.equal(
-    Buffer.from(b.toString('hex'), 'hex')
-    .indexOf('64', 0, 'hex'), 3);
-assert.equal(
-    Buffer.from(b.toString('hex'), 'hex')
-    .indexOf(Buffer.from('64', 'hex'), 0, 'hex'), 3);
+assert.strictEqual(
+  Buffer.from(b.toString('hex'), 'hex')
+    .indexOf('64', 0, 'hex'),
+  3
+);
+assert.strictEqual(
+  Buffer.from(b.toString('hex'), 'hex')
+    .indexOf(Buffer.from('64', 'hex'), 0, 'hex'),
+  3
+);
 
 // test base64 encoding
-assert.equal(
-    Buffer.from(b.toString('base64'), 'base64')
-    .indexOf('ZA==', 0, 'base64'), 3);
-assert.equal(
-    Buffer.from(b.toString('base64'), 'base64')
-    .indexOf(Buffer.from('ZA==', 'base64'), 0, 'base64'), 3);
+assert.strictEqual(
+  Buffer.from(b.toString('base64'), 'base64')
+    .indexOf('ZA==', 0, 'base64'),
+  3
+);
+assert.strictEqual(
+  Buffer.from(b.toString('base64'), 'base64')
+    .indexOf(Buffer.from('ZA==', 'base64'), 0, 'base64'),
+  3
+);
 
 // test ascii encoding
-assert.equal(
-    Buffer.from(b.toString('ascii'), 'ascii')
-    .indexOf('d', 0, 'ascii'), 3);
-assert.equal(
-    Buffer.from(b.toString('ascii'), 'ascii')
-    .indexOf(Buffer.from('d', 'ascii'), 0, 'ascii'), 3);
+assert.strictEqual(
+  Buffer.from(b.toString('ascii'), 'ascii')
+    .indexOf('d', 0, 'ascii'),
+  3
+);
+assert.strictEqual(
+  Buffer.from(b.toString('ascii'), 'ascii')
+    .indexOf(Buffer.from('d', 'ascii'), 0, 'ascii'),
+  3
+);
+
+// test latin1 encoding
+assert.strictEqual(
+  Buffer.from(b.toString('latin1'), 'latin1')
+    .indexOf('d', 0, 'latin1'),
+  3
+);
+assert.strictEqual(
+  Buffer.from(b.toString('latin1'), 'latin1')
+    .indexOf(Buffer.from('d', 'latin1'), 0, 'latin1'),
+  3
+);
+assert.strictEqual(
+  Buffer.from('aa\u00e8aa', 'latin1')
+    .indexOf('\u00e8', 'latin1'),
+  2
+);
+assert.strictEqual(
+  Buffer.from('\u00e8', 'latin1')
+    .indexOf('\u00e8', 'latin1'),
+  0
+);
+assert.strictEqual(
+  Buffer.from('\u00e8', 'latin1')
+    .indexOf(Buffer.from('\u00e8', 'latin1'), 'latin1'),
+  0
+);
 
 // test binary encoding
-assert.equal(
-    Buffer.from(b.toString('binary'), 'binary')
-    .indexOf('d', 0, 'binary'), 3);
-assert.equal(
-    Buffer.from(b.toString('binary'), 'binary')
-    .indexOf(Buffer.from('d', 'binary'), 0, 'binary'), 3);
-assert.equal(
-    Buffer.from('aa\u00e8aa', 'binary')
-    .indexOf('\u00e8', 'binary'), 2);
-assert.equal(
-    Buffer.from('\u00e8', 'binary')
-    .indexOf('\u00e8', 'binary'), 0);
-assert.equal(
-    Buffer.from('\u00e8', 'binary')
-    .indexOf(Buffer.from('\u00e8', 'binary'), 'binary'), 0);
+assert.strictEqual(
+  Buffer.from(b.toString('binary'), 'binary')
+    .indexOf('d', 0, 'binary'),
+  3
+);
+assert.strictEqual(
+  Buffer.from(b.toString('binary'), 'binary')
+    .indexOf(Buffer.from('d', 'binary'), 0, 'binary'),
+  3
+);
+assert.strictEqual(
+  Buffer.from('aa\u00e8aa', 'binary')
+    .indexOf('\u00e8', 'binary'),
+  2
+);
+assert.strictEqual(
+  Buffer.from('\u00e8', 'binary')
+    .indexOf('\u00e8', 'binary'),
+  0
+);
+assert.strictEqual(
+  Buffer.from('\u00e8', 'binary')
+    .indexOf(Buffer.from('\u00e8', 'binary'), 'binary'),
+  0
+);
 
 
 // test optional offset with passed encoding
@@ -185,7 +234,7 @@ assert.equal(-1, mixedByteStringUtf8.indexOf('\u0396'));
 // Long string that isn't a simple repeat of a shorter string.
 var longString = 'A';
 for (var i = 66; i < 76; i++) {  // from 'B' to 'K'
-  longString =  longString + String.fromCharCode(i) + longString;
+  longString = longString + String.fromCharCode(i) + longString;
 }
 
 var longBufferString = Buffer.from(longString);
@@ -223,6 +272,15 @@ var allCharsBufferUcs2 = Buffer.from(allCharsString, 'ucs2');
 // and UC16 subject.
 assert.equal(-1, allCharsBufferUtf8.indexOf('notfound'));
 assert.equal(-1, allCharsBufferUcs2.indexOf('notfound'));
+
+// Needle is longer than haystack, but only because it's encoded as UTF-16
+assert.strictEqual(Buffer.from('aaaa').indexOf('a'.repeat(4), 'ucs2'), -1);
+
+assert.strictEqual(Buffer.from('aaaa').indexOf('a'.repeat(4), 'utf8'), 0);
+assert.strictEqual(Buffer.from('aaaa').indexOf('你好', 'ucs2'), -1);
+
+// Haystack has odd length, but the needle is UCS2.
+// assert.strictEqual(Buffer.from('aaaaa').indexOf('b', 'ucs2'), -1);
 
 {
   // Find substrings in Utf8.
@@ -284,4 +342,182 @@ assert.throws(function() {
 assert.throws(function() {
   b.indexOf([]);
 });
+
+// All code for handling encodings is shared between Buffer.indexOf and
+// Buffer.lastIndexOf, so only testing the separate lastIndexOf semantics.
+
+// Test lastIndexOf basic functionality; Buffer b contains 'abcdef'.
+// lastIndexOf string:
+// assert.equal(b.lastIndexOf('a'), 0);
+// assert.equal(b.lastIndexOf('a', 1), 0);
+// assert.equal(b.lastIndexOf('b', 1), 1);
+// assert.equal(b.lastIndexOf('c', 1), -1);
+// assert.equal(b.lastIndexOf('a', -1), 0);
+// assert.equal(b.lastIndexOf('a', -4), 0);
+// assert.equal(b.lastIndexOf('a', -b.length), 0);
+// assert.equal(b.lastIndexOf('a', -b.length - 1), -1);
+// assert.equal(b.lastIndexOf('a', NaN), 0);
+// assert.equal(b.lastIndexOf('a', -Infinity), -1);
+// assert.equal(b.lastIndexOf('a', Infinity), 0);
+// lastIndexOf Buffer:
+// assert.equal(b.lastIndexOf(buf_a), 0);
+// assert.equal(b.lastIndexOf(buf_a, 1), 0);
+// assert.equal(b.lastIndexOf(buf_a, -1), 0);
+// assert.equal(b.lastIndexOf(buf_a, -4), 0);
+// assert.equal(b.lastIndexOf(buf_a, -b.length), 0);
+// assert.equal(b.lastIndexOf(buf_a, -b.length - 1), -1);
+// assert.equal(b.lastIndexOf(buf_a, NaN), 0);
+// assert.equal(b.lastIndexOf(buf_a, -Infinity), -1);
+// assert.equal(b.lastIndexOf(buf_a, Infinity), 0);
+// assert.equal(b.lastIndexOf(buf_bc), 1);
+// assert.equal(b.lastIndexOf(buf_bc, 2), 1);
+// assert.equal(b.lastIndexOf(buf_bc, -1), 1);
+// assert.equal(b.lastIndexOf(buf_bc, -3), 1);
+// assert.equal(b.lastIndexOf(buf_bc, -5), 1);
+// assert.equal(b.lastIndexOf(buf_bc, -6), -1);
+// assert.equal(b.lastIndexOf(buf_bc, NaN), 1);
+// assert.equal(b.lastIndexOf(buf_bc, -Infinity), -1);
+// assert.equal(b.lastIndexOf(buf_bc, Infinity), 1);
+// assert.equal(b.lastIndexOf(buf_f), b.length - 1);
+// assert.equal(b.lastIndexOf(buf_z), -1);
+// assert.equal(b.lastIndexOf(buf_empty), -1);
+// assert.equal(b.lastIndexOf(buf_empty, 1), -1);
+// assert.equal(b.lastIndexOf(buf_empty, b.length + 1), -1);
+// assert.equal(b.lastIndexOf(buf_empty, Infinity), -1);
+// lastIndexOf number:
+// assert.equal(b.lastIndexOf(0x61), 0);
+// assert.equal(b.lastIndexOf(0x61, 1), 0);
+// assert.equal(b.lastIndexOf(0x61, -1), 0);
+// assert.equal(b.lastIndexOf(0x61, -4), 0);
+// assert.equal(b.lastIndexOf(0x61, -b.length), 0);
+// assert.equal(b.lastIndexOf(0x61, -b.length - 1), -1);
+// assert.equal(b.lastIndexOf(0x61, NaN), 0);
+// assert.equal(b.lastIndexOf(0x61, -Infinity), -1);
+// assert.equal(b.lastIndexOf(0x61, Infinity), 0);
+// assert.equal(b.lastIndexOf(0x0), -1);
+
+// Test weird offset arguments.
+// Behaviour should match String.lastIndexOf:
+// assert.equal(b.lastIndexOf('b', 0), -1);
+// assert.equal(b.lastIndexOf('b', undefined), 1);
+// assert.equal(b.lastIndexOf('b', null), -1);
+// assert.equal(b.lastIndexOf('b', {}), 1);
+// assert.equal(b.lastIndexOf('b', []), -1);
+// assert.equal(b.lastIndexOf('b', [2]), 1);
+
+// Test needles longer than the haystack.
+// assert.strictEqual(b.lastIndexOf('aaaaaaaaaaaaaaa', 'ucs2'), -1);
+// assert.strictEqual(b.lastIndexOf('aaaaaaaaaaaaaaa', 'utf8'), -1);
+// assert.strictEqual(b.lastIndexOf('aaaaaaaaaaaaaaa', 'latin1'), -1);
+// assert.strictEqual(b.lastIndexOf('aaaaaaaaaaaaaaa', 'binary'), -1);
+// assert.strictEqual(b.lastIndexOf(Buffer.from('aaaaaaaaaaaaaaa')), -1);
+// assert.strictEqual(b.lastIndexOf('aaaaaaaaaaaaaaa', 2, 'ucs2'), -1);
+// assert.strictEqual(b.lastIndexOf('aaaaaaaaaaaaaaa', 3, 'utf8'), -1);
+// assert.strictEqual(b.lastIndexOf('aaaaaaaaaaaaaaa', 5, 'latin1'), -1);
+// assert.strictEqual(b.lastIndexOf('aaaaaaaaaaaaaaa', 5, 'binary'), -1);
+// assert.strictEqual(b.lastIndexOf(Buffer.from('aaaaaaaaaaaaaaa'), 7), -1);
+
+// 你好 expands to a total of 6 bytes using UTF-8 and 4 bytes using UTF-16
+// assert.strictEqual(buf_bc.lastIndexOf('你好', 'ucs2'), -1);
+// assert.strictEqual(buf_bc.lastIndexOf('你好', 'utf8'), -1);
+// assert.strictEqual(buf_bc.lastIndexOf('你好', 'latin1'), -1);
+// assert.strictEqual(buf_bc.lastIndexOf('你好', 'binary'), -1);
+// assert.strictEqual(buf_bc.lastIndexOf(Buffer.from('你好')), -1);
+// assert.strictEqual(buf_bc.lastIndexOf('你好', 2, 'ucs2'), -1);
+// assert.strictEqual(buf_bc.lastIndexOf('你好', 3, 'utf8'), -1);
+// assert.strictEqual(buf_bc.lastIndexOf('你好', 5, 'latin1'), -1);
+// assert.strictEqual(buf_bc.lastIndexOf('你好', 5, 'binary'), -1);
+// assert.strictEqual(buf_bc.lastIndexOf(Buffer.from('你好'), 7), -1);
+
+// Test lastIndexOf on a longer buffer:
+// var bufferString = new Buffer('a man a plan a canal panama');
+// assert.equal(15, bufferString.lastIndexOf('canal'));
+// assert.equal(21, bufferString.lastIndexOf('panama'));
+// assert.equal(0, bufferString.lastIndexOf('a man a plan a canal panama'));
+// assert.equal(-1, bufferString.lastIndexOf('a man a plan a canal mexico'));
+// assert.equal(-1, bufferString.lastIndexOf('a man a plan a canal mexico city'));
+// assert.equal(-1, bufferString.lastIndexOf(Buffer.from('a'.repeat(1000))));
+// assert.equal(0, bufferString.lastIndexOf('a man a plan', 4));
+// assert.equal(13, bufferString.lastIndexOf('a '));
+// assert.equal(13, bufferString.lastIndexOf('a ', 13));
+// assert.equal(6, bufferString.lastIndexOf('a ', 12));
+// assert.equal(0, bufferString.lastIndexOf('a ', 5));
+// assert.equal(13, bufferString.lastIndexOf('a ', -1));
+// assert.equal(0, bufferString.lastIndexOf('a ', -27));
+// assert.equal(-1, bufferString.lastIndexOf('a ', -28));
+
+// Test lastIndexOf for the case that the first character can be found,
+// but in a part of the buffer that does not make search to search
+// due do length constraints.
+// var abInUCS2 = Buffer.from('ab', 'ucs2');
+// assert.strictEqual(-1, Buffer.from('µaaaa¶bbbb', 'latin1').lastIndexOf('µ'));
+// assert.strictEqual(-1, Buffer.from('µaaaa¶bbbb', 'binary').lastIndexOf('µ'));
+// assert.strictEqual(-1, Buffer.from('bc').lastIndexOf('ab'));
+// assert.strictEqual(-1, Buffer.from('abc').lastIndexOf('qa'));
+// assert.strictEqual(-1, Buffer.from('abcdef').lastIndexOf('qabc'));
+// assert.strictEqual(-1, Buffer.from('bc').lastIndexOf(Buffer.from('ab')));
+// assert.strictEqual(-1, Buffer.from('bc', 'ucs2').lastIndexOf('ab', 'ucs2'));
+// assert.strictEqual(-1, Buffer.from('bc', 'ucs2').lastIndexOf(abInUCS2));
+
+// assert.strictEqual(0, Buffer.from('abc').lastIndexOf('ab'));
+// assert.strictEqual(0, Buffer.from('abc').lastIndexOf('ab', 1));
+// assert.strictEqual(0, Buffer.from('abc').lastIndexOf('ab', 2));
+// assert.strictEqual(0, Buffer.from('abc').lastIndexOf('ab', 3));
+
+// The above tests test the LINEAR and SINGLE-CHAR strategies.
+// Now, we test the BOYER-MOORE-HORSPOOL strategy.
+// Test lastIndexOf on a long buffer w multiple matches:
+// pattern = 'JABACABADABACABA';
+// assert.equal(1535, longBufferString.lastIndexOf(pattern));
+// assert.equal(1535, longBufferString.lastIndexOf(pattern, 1535));
+// assert.equal(511, longBufferString.lastIndexOf(pattern, 1534));
+
+// Finally, give it a really long input to trigger fallback from BMH to
+// regular BOYER-MOORE (which has better worst-case complexity).
+
+// Generate a really long Thue-Morse sequence of 'yolo' and 'swag',
+// "yolo swag swag yolo swag yolo yolo swag" ..., goes on for about 5MB.
+// This is hard to search because it all looks similar, but never repeats.
+
+// countBits returns the number of bits in the binary reprsentation of n.
+function countBits(n) {
+  for (var count = 0; n > 0; count++) {
+    n = n & (n - 1); // remove top bit
+  }
+  return count;
+}
+var parts = [];
+for (var i = 0; i < 1000000; i++) {
+  parts.push((countBits(i) % 2 === 0) ? 'yolo' : 'swag');
+}
+var reallyLong = new Buffer(parts.join(' '));
+assert.equal('yolo swag swag yolo', reallyLong.slice(0, 19).toString());
+
+// Expensive reverse searches. Stress test lastIndexOf:
+// pattern = reallyLong.slice(0, 100000);  // First 1/50th of the pattern.
+// assert.equal(4751360, reallyLong.lastIndexOf(pattern));
+// assert.equal(3932160, reallyLong.lastIndexOf(pattern, 4000000));
+// assert.equal(2949120, reallyLong.lastIndexOf(pattern, 3000000));
+// pattern = reallyLong.slice(100000, 200000);  // Second 1/50th.
+// assert.equal(4728480, reallyLong.lastIndexOf(pattern));
+// pattern = reallyLong.slice(0, 1000000);  // First 1/5th.
+// assert.equal(3932160, reallyLong.lastIndexOf(pattern));
+// pattern = reallyLong.slice(0, 2000000);  // first 2/5ths.
+// assert.equal(0, reallyLong.lastIndexOf(pattern));
+
+// test truncation of Number arguments to uint8
+{
+  var buf = Buffer.from('this is a test');
+  assert.strictEqual(buf.indexOf(0x6973), 3);
+  assert.strictEqual(buf.indexOf(0x697320), 4);
+  assert.strictEqual(buf.indexOf(0x69732069), 2);
+  assert.strictEqual(buf.indexOf(0x697374657374), 0);
+  assert.strictEqual(buf.indexOf(0x69737374), 0);
+  assert.strictEqual(buf.indexOf(0x69737465), 11);
+  assert.strictEqual(buf.indexOf(0x69737465), 11);
+  assert.strictEqual(buf.indexOf(-140), 0);
+  assert.strictEqual(buf.indexOf(-152), 1);
+  assert.strictEqual(buf.indexOf(0xff), -1);
+  assert.strictEqual(buf.indexOf(0xffff), -1);
+}
 

--- a/test/node/test-buffer-indexof.js
+++ b/test/node/test-buffer-indexof.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (Buffer.TYPED_ARRAY_SUPPORT) return;
+if (!Buffer.TYPED_ARRAY_SUPPORT) return;
 
 var assert = require('assert');
 

--- a/test/node/test-buffer-inheritance.js
+++ b/test/node/test-buffer-inheritance.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (!Buffer.TYPED_ARRAY_SUPPORT) return;
+
 
 
 var assert = require('assert');

--- a/test/node/test-buffer-inheritance.js
+++ b/test/node/test-buffer-inheritance.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (Buffer.TYPED_ARRAY_SUPPORT) return;
+if (!Buffer.TYPED_ARRAY_SUPPORT) return;
 
 
 var assert = require('assert');

--- a/test/node/test-buffer-inspect.js
+++ b/test/node/test-buffer-inspect.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (!Buffer.TYPED_ARRAY_SUPPORT) return;
+
 
 var assert = require('assert');
 

--- a/test/node/test-buffer-inspect.js
+++ b/test/node/test-buffer-inspect.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (Buffer.TYPED_ARRAY_SUPPORT) return;
+if (!Buffer.TYPED_ARRAY_SUPPORT) return;
 
 var assert = require('assert');
 

--- a/test/node/test-buffer-iterator.js
+++ b/test/node/test-buffer-iterator.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (!Buffer.TYPED_ARRAY_SUPPORT) return;
+
 
 var assert = require('assert');
 

--- a/test/node/test-buffer-iterator.js
+++ b/test/node/test-buffer-iterator.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (Buffer.TYPED_ARRAY_SUPPORT) return;
+if (!Buffer.TYPED_ARRAY_SUPPORT) return;
 
 var assert = require('assert');
 

--- a/test/node/test-buffer-safe-unsafe.js
+++ b/test/node/test-buffer-safe-unsafe.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (!Buffer.TYPED_ARRAY_SUPPORT) return;
+
 
 
 var assert = require('assert');

--- a/test/node/test-buffer-safe-unsafe.js
+++ b/test/node/test-buffer-safe-unsafe.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (Buffer.TYPED_ARRAY_SUPPORT) return;
+if (!Buffer.TYPED_ARRAY_SUPPORT) return;
 
 
 var assert = require('assert');

--- a/test/node/test-buffer-slow.js
+++ b/test/node/test-buffer-slow.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (!Buffer.TYPED_ARRAY_SUPPORT) return;
+
 
 
 var assert = require('assert');

--- a/test/node/test-buffer-slow.js
+++ b/test/node/test-buffer-slow.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (Buffer.TYPED_ARRAY_SUPPORT) return;
+if (!Buffer.TYPED_ARRAY_SUPPORT) return;
 
 
 var assert = require('assert');

--- a/test/node/test-buffer-swap.js
+++ b/test/node/test-buffer-swap.js
@@ -1,12 +1,12 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (!Buffer.TYPED_ARRAY_SUPPORT) return;
+
 
 
 var assert = require('assert');
 
 // Test buffers small enough to use the JS implementation
-const buf = Buffer.from([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
+var buf = Buffer.from([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
                          0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10]);
 
 assert.strictEqual(buf, buf.swap16());
@@ -34,7 +34,7 @@ assert.deepStrictEqual(buf3, Buffer.from([0x1, 0x5, 0x4, 0x3, 0x2, 0x6, 0x7]));
 buf3.slice(1, 5).swap16();
 assert.deepStrictEqual(buf3, Buffer.from([0x1, 0x4, 0x5, 0x2, 0x3, 0x6, 0x7]));
 
-const buf3_64 = Buffer.from([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+var buf3_64 = Buffer.from([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
                              0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
                              0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
                              0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10]);
@@ -63,10 +63,9 @@ var buf7 = Buffer.from(bu7A.buffer, bu7A.byteOffset);
 buf6.swap32();
 assert.deepStrictEqual(buf6, buf7);
 
-
 var buf8A = new Uint8Array(256 * 8);
 var buf9A = new Uint8Array(256 * 8);
-for (let i = 0; i < buf8A.length; i++) {
+for (var i = 0; i < buf8A.length; i++) {
   buf8A[i] = i % 8;
   buf9A[buf9A.length - i - 1] = i % 8;
 }
@@ -79,10 +78,10 @@ assert.deepStrictEqual(buf8, buf9);
 // Test native code with buffers that are not memory-aligned
 var buf10A = new Uint8Array(256 * 8);
 var buf11A = new Uint8Array(256 * 8 - 2);
-for (let i = 0; i < buf10A.length; i++) {
+for (var i = 0; i < buf10A.length; i++) {
   buf10A[i] = i % 2;
 }
-for (let i = 1; i < buf11A.length; i++) {
+for (var i = 1; i < buf11A.length; i++) {
   buf11A[buf11A.length - i] = (i + 1) % 2;
 }
 var buf10 = Buffer.from(buf10A.buffer, buf10A.byteOffset);
@@ -96,10 +95,10 @@ assert.deepStrictEqual(buf10.slice(0, buf11.length), buf11);
 
 var buf12A = new Uint8Array(256 * 8);
 var buf13A = new Uint8Array(256 * 8 - 4);
-for (let i = 0; i < buf12A.length; i++) {
+for (var i = 0; i < buf12A.length; i++) {
   buf12A[i] = i % 4;
 }
-for (let i = 1; i < buf13A.length; i++) {
+for (var i = 1; i < buf13A.length; i++) {
   buf13A[buf13A.length - i] = (i + 1) % 4;
 }
 var buf12 = Buffer.from(buf12A.buffer, buf12A.byteOffset);
@@ -113,10 +112,10 @@ assert.deepStrictEqual(buf12.slice(0, buf13.length), buf13);
 
 var buf14A = new Uint8Array(256 * 8);
 var buf15A = new Uint8Array(256 * 8 - 8);
-for (let i = 0; i < buf14A.length; i++) {
+for (var i = 0; i < buf14A.length; i++) {
   buf14A[i] = i % 8;
 }
-for (let i = 1; i < buf15A.length; i++) {
+for (var i = 1; i < buf15A.length; i++) {
   buf15A[buf15A.length - i] = (i + 1) % 8;
 }
 var buf14 = Buffer.from(buf14A.buffer, buf14A.byteOffset);
@@ -128,9 +127,9 @@ buf14.slice(1, buf14.length - 7).swap64();
 assert.deepStrictEqual(buf14.slice(0, buf15.length), buf15);
 
 // Length assertions
-const re16 = /Buffer size must be a multiple of 16-bits/;
-const re32 = /Buffer size must be a multiple of 32-bits/;
-const re64 = /Buffer size must be a multiple of 64-bits/;
+var re16 = /Buffer size must be a multiple of 16-bits/;
+var re32 = /Buffer size must be a multiple of 32-bits/;
+var re64 = /Buffer size must be a multiple of 64-bits/;
 
 assert.throws(() => Buffer.from(buf3).swap16(), re16);
 assert.throws(() => Buffer.alloc(1025).swap16(), re16);
@@ -139,3 +138,4 @@ assert.throws(() => buf3.slice(1, 3).swap32(), re32);
 assert.throws(() => Buffer.alloc(1025).swap32(), re32);
 assert.throws(() => buf3.slice(1, 3).swap64(), re64);
 assert.throws(() => Buffer.alloc(1025).swap64(), re64);
+

--- a/test/node/test-buffer-swap.js
+++ b/test/node/test-buffer-swap.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (Buffer.TYPED_ARRAY_SUPPORT) return;
+if (!Buffer.TYPED_ARRAY_SUPPORT) return;
 
 
 var assert = require('assert');

--- a/test/node/test-buffer-zero-fill-cli.js
+++ b/test/node/test-buffer-zero-fill-cli.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (Buffer.TYPED_ARRAY_SUPPORT) return;
+if (!Buffer.TYPED_ARRAY_SUPPORT) return;
 // Flags: --zero-fill-buffers
 
 // when using --zero-fill-buffers, every Buffer and SlowBuffer

--- a/test/node/test-buffer-zero-fill-cli.js
+++ b/test/node/test-buffer-zero-fill-cli.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (!Buffer.TYPED_ARRAY_SUPPORT) return;
+
 // Flags: --zero-fill-buffers
 
 // when using --zero-fill-buffers, every Buffer and SlowBuffer

--- a/test/node/test-buffer-zero-fill-reset.js
+++ b/test/node/test-buffer-zero-fill-reset.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (!Buffer.TYPED_ARRAY_SUPPORT) return;
+
 
 
 var assert = require('assert');

--- a/test/node/test-buffer-zero-fill-reset.js
+++ b/test/node/test-buffer-zero-fill-reset.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (Buffer.TYPED_ARRAY_SUPPORT) return;
+if (!Buffer.TYPED_ARRAY_SUPPORT) return;
 
 
 var assert = require('assert');

--- a/test/node/test-buffer.js
+++ b/test/node/test-buffer.js
@@ -1,7 +1,7 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (!Buffer.TYPED_ARRAY_SUPPORT) return;
-var common = {};
+
+var common = { skip: function () {} };
 var assert = require('assert');
 
 var Buffer = require('../../').Buffer;
@@ -239,6 +239,7 @@ assert.strictEqual('Unknown encoding: invalid', caught_error.message);
 // try to create 0-length buffers
 new Buffer('');
 new Buffer('', 'ascii');
+new Buffer('', 'latin1');
 new Buffer('', 'binary');
 Buffer(0);
 
@@ -689,6 +690,7 @@ assert.equal(dot.toString('base64'), '//4uAA==');
   for (var i = 0; i < segments.length; ++i) {
     pos += b.write(segments[i], pos, 'base64');
   }
+  assert.equal(b.toString('latin1', 0, pos), 'Madness?! This is node.js!');
   assert.equal(b.toString('binary', 0, pos), 'Madness?! This is node.js!');
 }
 
@@ -750,6 +752,15 @@ var hexb2 = new Buffer(hexStr, 'hex');
 for (var i = 0; i < 256; i++) {
   assert.equal(hexb2[i], hexb[i]);
 }
+
+// Test single hex character throws TypeError
+// - https://github.com/nodejs/node/issues/6770
+assert.throws(function() {
+  Buffer.from('A', 'hex');
+}, TypeError);
+
+// Test single base64 char encodes as 0
+// assert.strictEqual(Buffer.from('A', 'base64').length, 0);
 
 {
   // test an invalid slice end.
@@ -837,6 +848,23 @@ assert.equal(0, Buffer('hello').slice(0, 0).length);
   b.write('あいうえお', encoding);
   assert.equal(b.toString(encoding), 'あいうえお');
 });
+
+{
+  // latin1 encoding should write only one byte per character.
+  var b = Buffer([0xde, 0xad, 0xbe, 0xef]);
+  var s = String.fromCharCode(0xffff);
+  b.write(s, 0, 'latin1');
+  assert.equal(0xff, b[0]);
+  assert.equal(0xad, b[1]);
+  assert.equal(0xbe, b[2]);
+  assert.equal(0xef, b[3]);
+  s = String.fromCharCode(0xaaee);
+  b.write(s, 0, 'latin1');
+  assert.equal(0xee, b[0]);
+  assert.equal(0xad, b[1]);
+  assert.equal(0xbe, b[2]);
+  assert.equal(0xef, b[3]);
+}
 
 {
   // Binary encoding should write only one byte per character.
@@ -966,6 +994,9 @@ assert.equal(0, Buffer('hello').slice(0, 0).length);
   // test for buffer overrun
   var buf = new Buffer([0, 0, 0, 0, 0]); // length: 5
   var sub = buf.slice(0, 4);         // length: 4
+  written = sub.write('12345', 'latin1');
+  assert.equal(written, 4);
+  assert.equal(buf[4], 0);
   written = sub.write('12345', 'binary');
   assert.equal(written, 4);
   assert.equal(buf[4], 0);
@@ -987,7 +1018,7 @@ assert.equal(Buffer('99').length, 2);
 assert.equal(Buffer('13.37').length, 5);
 
 // Ensure that the length argument is respected.
-'ascii utf8 hex base64 binary'.split(' ').forEach(function(enc) {
+'ascii utf8 hex base64 latin1 binary'.split(' ').forEach(function(enc) {
   assert.equal(Buffer(1).write('aaaaaa', 0, 1, enc), 1);
 });
 
@@ -1006,6 +1037,7 @@ Buffer(Buffer(0), 0, 0);
   'utf8',
   'utf-8',
   'ascii',
+  'latin1',
   'binary',
   'base64',
   'ucs2',
@@ -1018,34 +1050,34 @@ Buffer(Buffer(0), 0, 0);
 [ 'utf9',
   'utf-7',
   'Unicode-FTW',
-  'new gnu gun'  ].forEach(function(enc) {
+  'new gnu gun' ].forEach(function(enc) {
     assert.equal(Buffer.isEncoding(enc), false);
   });
 
 
 // GH-5110
-(function() {
+{
   var buffer = new Buffer('test');
   var string = JSON.stringify(buffer);
 
-  assert.equal(string, '{"type":"Buffer","data":[116,101,115,116]}');
+  assert.strictEqual(string, '{"type":"Buffer","data":[116,101,115,116]}');
 
   assert.deepStrictEqual(buffer, JSON.parse(string, function(key, value) {
     return value && value.type === 'Buffer'
       ? new Buffer(value.data)
       : value;
   }));
-})();
+}
 
 // issue GH-7849
-(function() {
+{
   var buf = new Buffer('test');
   var json = JSON.stringify(buf);
   var obj = JSON.parse(json);
   var copy = new Buffer(obj);
 
   assert(buf.equals(copy));
-})();
+}
 
 // issue GH-4331
 assert.throws(function() {
@@ -1161,29 +1193,29 @@ assert.throws(function() {
 });
 
 // test for common read(U)IntLE/BE
-(function() {
+{
   var buf = new Buffer([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
 
-  assert.equal(buf.readUIntLE(0, 1), 0x01);
-  assert.equal(buf.readUIntBE(0, 1), 0x01);
-  assert.equal(buf.readUIntLE(0, 3), 0x030201);
-  assert.equal(buf.readUIntBE(0, 3), 0x010203);
-  assert.equal(buf.readUIntLE(0, 5), 0x0504030201);
-  assert.equal(buf.readUIntBE(0, 5), 0x0102030405);
-  assert.equal(buf.readUIntLE(0, 6), 0x060504030201);
-  assert.equal(buf.readUIntBE(0, 6), 0x010203040506);
-  assert.equal(buf.readIntLE(0, 1), 0x01);
-  assert.equal(buf.readIntBE(0, 1), 0x01);
-  assert.equal(buf.readIntLE(0, 3), 0x030201);
-  assert.equal(buf.readIntBE(0, 3), 0x010203);
-  assert.equal(buf.readIntLE(0, 5), 0x0504030201);
-  assert.equal(buf.readIntBE(0, 5), 0x0102030405);
-  assert.equal(buf.readIntLE(0, 6), 0x060504030201);
-  assert.equal(buf.readIntBE(0, 6), 0x010203040506);
-})();
+  assert.strictEqual(buf.readUIntLE(0, 1), 0x01);
+  assert.strictEqual(buf.readUIntBE(0, 1), 0x01);
+  assert.strictEqual(buf.readUIntLE(0, 3), 0x030201);
+  assert.strictEqual(buf.readUIntBE(0, 3), 0x010203);
+  assert.strictEqual(buf.readUIntLE(0, 5), 0x0504030201);
+  assert.strictEqual(buf.readUIntBE(0, 5), 0x0102030405);
+  assert.strictEqual(buf.readUIntLE(0, 6), 0x060504030201);
+  assert.strictEqual(buf.readUIntBE(0, 6), 0x010203040506);
+  assert.strictEqual(buf.readIntLE(0, 1), 0x01);
+  assert.strictEqual(buf.readIntBE(0, 1), 0x01);
+  assert.strictEqual(buf.readIntLE(0, 3), 0x030201);
+  assert.strictEqual(buf.readIntBE(0, 3), 0x010203);
+  assert.strictEqual(buf.readIntLE(0, 5), 0x0504030201);
+  assert.strictEqual(buf.readIntBE(0, 5), 0x0102030405);
+  assert.strictEqual(buf.readIntLE(0, 6), 0x060504030201);
+  assert.strictEqual(buf.readIntBE(0, 6), 0x010203040506);
+}
 
 // test for common write(U)IntLE/BE
-(function() {
+{
   var buf = Buffer(3);
   buf.writeUIntLE(0x123456, 0, 3);
   assert.deepStrictEqual(buf.toJSON().data, [0x56, 0x34, 0x12]);
@@ -1273,10 +1305,10 @@ assert.throws(function() {
   buf.writeIntBE(-0x0012000000, 0, 5);
   assert.deepStrictEqual(buf.toJSON().data, [0xff, 0xee, 0x00, 0x00, 0x00]);
   assert.equal(buf.readIntBE(0, 5), -0x0012000000);
-})();
+}
 
 // test Buffer slice
-(function() {
+{
   var buf = new Buffer('0123456789');
   assert.equal(buf.slice(-10, 10), '0123456789');
   assert.equal(buf.slice(-20, 10), '0123456789');
@@ -1311,7 +1343,7 @@ assert.throws(function() {
   }
 
   var utf16Buf = new Buffer('0123456789', 'utf16le');
-  // assert.deepStrictEqual(utf16Buf.slice(0, 6), Buffer('012', 'utf16le'));
+  assert.deepStrictEqual(utf16Buf.slice(0, 6), Buffer('012', 'utf16le'));
 
   assert.equal(buf.slice('0', '1'), '0');
   assert.equal(buf.slice('-5', '10'), '56789');
@@ -1324,7 +1356,7 @@ assert.throws(function() {
   // try to slice a zero length Buffer
   // see https://github.com/joyent/node/issues/5881
   SlowBuffer(0).slice(0, 1);
-})();
+}
 
 // Regression test for #5482: should throw but not assert in C++ land.
 assert.throws(function() {
@@ -1333,20 +1365,20 @@ assert.throws(function() {
 
 // Regression test for #6111. Constructing a buffer from another buffer
 // should a) work, and b) not corrupt the source buffer.
-(function() {
+{
   var a = [0];
   for (var i = 0; i < 7; ++i) a = a.concat(a);
   a = a.map(function(_, i) { return i; });
   var b = Buffer(a);
   var c = Buffer(b);
-  assert.equal(b.length, a.length);
-  assert.equal(c.length, a.length);
+  assert.strictEqual(b.length, a.length);
+  assert.strictEqual(c.length, a.length);
   for (var i = 0, k = a.length; i < k; ++i) {
-    assert.equal(a[i], i);
-    assert.equal(b[i], i);
-    assert.equal(c[i], i);
+    assert.strictEqual(a[i], i);
+    assert.strictEqual(b[i], i);
+    assert.strictEqual(c[i], i);
   }
-})();
+}
 
 
 assert.throws(function() {
@@ -1369,7 +1401,7 @@ if (common.hasCrypto) {
     1 /*crypto.createHash('sha1').update(b2).digest('hex')*/
   );
 } else {
-//   console.log('1..0 # Skipped: missing crypto');
+  common.skip('missing crypto');
 }
 
 // Test Compare
@@ -1458,4 +1490,38 @@ assert.equal(Buffer.prototype.parent, undefined);
 assert.equal(Buffer.prototype.offset, undefined);
 assert.equal(SlowBuffer.prototype.parent, undefined);
 assert.equal(SlowBuffer.prototype.offset, undefined);
+
+{
+  // Test that large negative Buffer length inputs don't affect the pool offset.
+  assert.deepStrictEqual(Buffer(-Buffer.poolSize), Buffer.from(''));
+  assert.deepStrictEqual(Buffer(-100), Buffer.from(''));
+  assert.deepStrictEqual(Buffer.allocUnsafe(-Buffer.poolSize), Buffer.from(''));
+  assert.deepStrictEqual(Buffer.allocUnsafe(-100), Buffer.from(''));
+
+  // Check pool offset after that by trying to write string into the pool.
+  assert.doesNotThrow(() => Buffer.from('abc'));
+}
+
+
+// Test failed or zero-sized Buffer allocations not affecting typed arrays
+{
+  var zeroArray = new Uint32Array(10).fill(0);
+  var sizes = [1e10, 0, 0.1, -1, 'a', undefined, null, NaN];
+  var allocators = [
+    Buffer,
+    SlowBuffer,
+    Buffer.alloc,
+    Buffer.allocUnsafe,
+    Buffer.allocUnsafeSlow
+  ];
+  for (var allocator of allocators) {
+    for (var size of sizes) {
+      try {
+        allocator(size);
+      } catch (e) {
+        assert.deepStrictEqual(new Uint32Array(10), zeroArray);
+      }
+    }
+  }
+}
 

--- a/test/node/test-buffer.js
+++ b/test/node/test-buffer.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-if (Buffer.TYPED_ARRAY_SUPPORT) return;
+if (!Buffer.TYPED_ARRAY_SUPPORT) return;
 var common = {};
 var assert = require('assert');
 


### PR DESCRIPTION
There have been lots of changes to the node.js buffer tests since we last synced them. This PR brings our tests in line with what's in Node.js core. These also helped us catch several bugs in our implementation:

- Fix: treat numbers as unsigned 8-bit for .indexOf and .includes
- Fix: buffer should only be as long as the valid part of a hex string
- Add 'latin1' encoding (alias for 'binary')
- Remove deprecated 'raw' and 'raws' encoding

There are a few tests that we're still failing (but this has been the case for a while): 

- Handling invalid base64 better -- truncating the buffer at the point of the invalid data
- missing the .lastIndexOf (see #114)

The asserts that relate to the above issues remain commented out. Additionally, a stub implementation of .lastIndexOf has been added that just throws an exception instead of letting the Uint8Array implementation's .lastIndexOf be exposed, since that one has a different interface.

Also, pulling in these new tests uncovered a bug in Node.js's `assert` package. See: https://github.com/nodejs/node/issues/8001 So there's a dirty hack to workaround that in `test/node/test-buffer-badhex.js` until the issue is fixed in a shipping version of Node.js v6.