### PR TITLE
sync tests; throw on negative .allocUnsafe() argument; remove hacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,6 +165,8 @@ if (Buffer.TYPED_ARRAY_SUPPORT) {
 function assertSize (size) {
   if (typeof size !== 'number') {
     throw new TypeError('"size" argument must be a number')
+  } else if (size < 0) {
+    throw new RangeError('"size" argument must not be negative')
   }
 }
 
@@ -241,7 +243,7 @@ function fromString (that, string, encoding) {
 }
 
 function fromArrayLike (that, array) {
-  var length = checked(array.length) | 0
+  var length = array.length < 0 ? 0 : checked(array.length) | 0
   that = createBuffer(that, length)
   for (var i = 0; i < length; i += 1) {
     that[i] = array[i] & 255
@@ -310,7 +312,7 @@ function fromObject (that, obj) {
 }
 
 function checked (length) {
-  // Note: cannot use `length < kMaxLength` here because that fails when
+  // Note: cannot use `length < kMaxLength()` here because that fails when
   // length is NaN (which is otherwise coerced to zero.)
   if (length >= kMaxLength()) {
     throw new RangeError('Attempt to allocate Buffer larger than maximum ' +

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -983,7 +983,6 @@ assert.equal(0, Buffer.from('hello').slice(0, 0).length);
 Buffer.allocUnsafe(3.3).fill().toString();
   // throws bad argument error in commit 43cb4ec
 Buffer.alloc(3.3).fill().toString();
-assert.equal(Buffer.allocUnsafe(-1).length, 0);
 assert.equal(Buffer.allocUnsafe(NaN).length, 0);
 assert.equal(Buffer.allocUnsafe(3.3).length, 3);
 assert.equal(Buffer.from({length: 3.3}).length, 3);
@@ -1481,4 +1480,22 @@ assert.equal(ubuf.buffer.byteLength, 10);
 assert.doesNotThrow(() => {
   Buffer.from(new ArrayBuffer());
 });
+
+assert.throws(() => Buffer.alloc(-Buffer.poolSize),
+              '"size" argument must not be negative');
+assert.throws(() => Buffer.alloc(-100),
+              '"size" argument must not be negative');
+assert.throws(() => Buffer.allocUnsafe(-Buffer.poolSize),
+              '"size" argument must not be negative');
+assert.throws(() => Buffer.allocUnsafe(-100),
+              '"size" argument must not be negative');
+assert.throws(() => Buffer.allocUnsafeSlow(-Buffer.poolSize),
+              '"size" argument must not be negative');
+assert.throws(() => Buffer.allocUnsafeSlow(-100),
+              '"size" argument must not be negative');
+
+assert.throws(() => Buffer.alloc({ valueOf: () => 1 }),
+              /"size" argument must be a number/);
+assert.throws(() => Buffer.alloc({ valueOf: () => -1 }),
+              /"size" argument must be a number/);
 

--- a/test/node/test-buffer-badhex.js
+++ b/test/node/test-buffer-badhex.js
@@ -5,47 +5,6 @@ var Buffer = require('../../').Buffer;
 var assert = require('assert');
 var Buffer = require('../../').Buffer;
 
-/**
- * TEMPORARY HACK UNTIL THIS ASSERT BUG IS FIXED IN NODE CORE
- * https://github.com/nodejs/node/issues/8001
- */
-var pToString = function (obj) { return Object.prototype.toString.call(obj) }
-var _deepStrictEqual = assert.deepStrictEqual
-assert.deepStrictEqual = function (actual, expected, msg) {
-  if (typeof ArrayBuffer !== 'undefined' && ArrayBuffer.isView(actual) &&
-      ArrayBuffer.isView(expected) && !require('buffer').Buffer.isBuffer(actual) &&
-      !require('buffer').Buffer.isBuffer(expected) && pToString(actual) === pToString(expected) &&
-      !(actual instanceof Float32Array || actual instanceof Float64Array)) {
-    assert.equal(Buffer.compare(Buffer.from(actual.buffer,
-                                            actual.byteOffset,
-                                            actual.byteLength),
-                             Buffer.from(expected.buffer,
-                                         expected.byteOffset,
-                                         expected.byteLength)), 0);
-  } else {
-    _deepStrictEqual.call(assert, actual, expected, msg)
-  }
-}
-var _deepEqual = assert.deepEqual
-assert.deepEqual = function (actual, expected, msg) {
-  if (typeof ArrayBuffer !== 'undefined' && ArrayBuffer.isView(actual) &&
-      ArrayBuffer.isView(expected) && !require('buffer').Buffer.isBuffer(actual) &&
-      !require('buffer').Buffer.isBuffer(expected) && pToString(actual) === pToString(expected) &&
-      !(actual instanceof Float32Array || actual instanceof Float64Array)) {
-    assert.ok(Buffer.compare(Buffer.from(actual.buffer,
-                                         actual.byteOffset,
-                                         actual.byteLength),
-                             Buffer.from(expected.buffer,
-                                         expected.byteOffset,
-                                         expected.byteLength)) === 0);
-  } else {
-    _deepEqual.call(assert, actual, expected, msg)
-  }
-}
-/**
- * END HACK
- */
-
 // Test hex strings and bad hex strings
 {
   var buf1 = Buffer.alloc(4);

--- a/test/node/test-buffer.js
+++ b/test/node/test-buffer.js
@@ -1007,7 +1007,6 @@ assert.equal(0, Buffer('hello').slice(0, 0).length);
 
 // Call .fill() first, stops valgrind warning about uninitialized memory reads.
 Buffer(3.3).fill().toString(); // throws bad argument error in commit 43cb4ec
-assert.equal(Buffer(-1).length, 0);
 assert.equal(Buffer(NaN).length, 0);
 assert.equal(Buffer(3.3).length, 3);
 assert.equal(Buffer({length: 3.3}).length, 3);
@@ -1493,10 +1492,10 @@ assert.equal(SlowBuffer.prototype.offset, undefined);
 
 {
   // Test that large negative Buffer length inputs don't affect the pool offset.
-  assert.deepStrictEqual(Buffer(-Buffer.poolSize), Buffer.from(''));
-  assert.deepStrictEqual(Buffer(-100), Buffer.from(''));
-  assert.deepStrictEqual(Buffer.allocUnsafe(-Buffer.poolSize), Buffer.from(''));
-  assert.deepStrictEqual(Buffer.allocUnsafe(-100), Buffer.from(''));
+  // Use the fromArrayLike() variant here because it's more lenient
+  // about its input and passes the length directly to allocate().
+  assert.deepStrictEqual(Buffer({ length: -Buffer.poolSize }), Buffer.from(''));
+  assert.deepStrictEqual(Buffer({ length: -100 }), Buffer.from(''));
 
   // Check pool offset after that by trying to write string into the pool.
   assert.doesNotThrow(() => Buffer.from('abc'));
@@ -1524,4 +1523,12 @@ assert.equal(SlowBuffer.prototype.offset, undefined);
     }
   }
 }
+
+// Test that large negative Buffer length inputs throw errors.
+assert.throws(() => Buffer(-Buffer.poolSize),
+              '"size" argument must not be negative');
+assert.throws(() => Buffer(-100),
+              '"size" argument must not be negative');
+assert.throws(() => Buffer(-1),
+              '"size" argument must not be negative');
 


### PR DESCRIPTION
- sync node.js tests to master (node v6.4.0)
- throw on negative .allocUnsafe() argument (to match new node v6.4.0 behavior)
- remove assert hack (Bug in node.js core was fixed in node v6.4.0!)
