### PR TITLE
Remove isarray dep.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ instance methods, and class methods that are supported.
 
 ## features
 
-- Manipulate binary data like a boss, in all browsers -- even IE6!
+- Manipulate binary data like a boss, in all browsers!
 - Super fast. Backed by Typed Arrays (`Uint8Array`/`ArrayBuffer`, not `Object`)
 - Extremely small bundle size (**5.04KB minified + gzipped**, 35.5KB with comments)
-- Excellent browser support (IE 6+, Chrome 4+, Firefox 3+, Safari 5.1+, Opera 11+, iOS, etc.)
+- Excellent browser support (IE 11, Edge, Chrome, Firefox, Safari 5.1+, Opera, iOS, etc.)
 - Preserves Node API exactly, with one minor difference (see below)
-- Square-bracket `buf[4]` notation works, even in old browsers like IE6!
+- Square-bracket `buf[4]` notation works!
 - Does not modify any browser prototypes or put anything on `window`
 - Comprehensive test suite (including all buffer tests from node.js core)
 

--- a/bin/zuul-es5.yml
+++ b/bin/zuul-es5.yml
@@ -5,7 +5,7 @@ browsers:
   - name: safari
     version: latest
   - name: ie
-    version: 8..latest
+    version: 11..latest
   - name: microsoftedge
     version: 13..latest
   - name: android

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@
 
 var base64 = require('base64-js')
 var ieee754 = require('ieee754')
-var isArray = require('isarray')
 
 exports.Buffer = Buffer
 exports.SlowBuffer = SlowBuffer
@@ -302,7 +301,7 @@ function fromObject (that, obj) {
       return fromArrayLike(that, obj)
     }
 
-    if (obj.type === 'Buffer' && isArray(obj.data)) {
+    if (obj.type === 'Buffer' && Array.isArray(obj.data)) {
       return fromArrayLike(that, obj.data)
     }
   }
@@ -374,7 +373,7 @@ Buffer.isEncoding = function isEncoding (encoding) {
 }
 
 Buffer.concat = function concat (list, length) {
-  if (!isArray(list)) {
+  if (!Array.isArray(list)) {
     throw new TypeError('"list" argument must be an Array of Buffers')
   }
 

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   ],
   "dependencies": {
     "base64-js": "^1.0.2",
-    "ieee754": "^1.1.4",
-    "isarray": "^1.0.0"
+    "ieee754": "^1.1.4"
   },
   "devDependencies": {
     "benchmark": "^2.0.0",


### PR DESCRIPTION
Hi @feross!

The [isarray](https://www.npmjs.com/package/isarray) package [is being deprecated](https://github.com/juliangruber/isarray/issues/10) since IE < 11 is no longer supported by MS & IE 8 was the last browser that needed it. For the fringes, folks tend to use something like [es-shim](https://github.com/es-shims).

The `Array.isArray` method is supported by all Node versions, Rhino, iOS, Android, and headless browser enviros (like PhantomJS v1, SlimerJS).

With that in mind this PR removes it from `buffer`.

*Note: I don't think test fails are related to this change.*