### PR TITLE
Remove old browser note. [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,26 +78,6 @@ single octet.
 The `Uint8Array` prototype remains unmodified.
 
 
-## one minor difference
-
-#### In old browsers, `buf.slice()` does not modify parent buffer's memory
-
-If you only support modern browsers (specifically, those with typed array support),
-then this issue does not affect you. If you support super old browsers, then read on.
-
-In node, the `slice()` method returns a new `Buffer` that shares underlying memory
-with the original Buffer. When you modify one buffer, you modify the other.
-[Read more.](https://nodejs.org/api/buffer.html#buffer_buf_slice_start_end)
-
-In browsers with typed array support, this `Buffer` implementation supports this
-behavior. In browsers without typed arrays, an alternate buffer implementation is
-used that is based on `Object` which has no mechanism to point separate
-`Buffer`s to the same underlying slab of memory.
-
-You can see which browser versions lack typed array support
-[here](https://github.com/feross/buffer/blob/master/index.js#L22-L48).
-
-
 ## tracking the latest node api
 
 This module tracks the Buffer API in the latest (unstable) version of node.js. The Buffer


### PR DESCRIPTION
I noticed the readme still had an old browser note (those that don't support typed arrays).