### PR TITLE
adventure-yunfei fix: wrong overwritting of not writable Unit8Array.from

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,9 +84,6 @@ function Buffer (arg, encodingOrOffset, length) {
   return from(arg, encodingOrOffset, length)
 }
 
-Buffer.prototype.__proto__ = Uint8Array.prototype
-Buffer.__proto__ = Uint8Array
-
 // Fix subarray() in ES2016. See: https://github.com/feross/buffer/pull/97
 if (typeof Symbol !== 'undefined' && Symbol.species &&
     Buffer[Symbol.species] === Buffer) {
@@ -127,6 +124,10 @@ function from (value, encodingOrOffset, length) {
 Buffer.from = function (value, encodingOrOffset, length) {
   return from(value, encodingOrOffset, length)
 }
+
+Buffer.prototype.__proto__ = Uint8Array.prototype
+// Assign Uint8Array as proto AFTER setting Buffer.from
+Buffer.__proto__ = Uint8Array
 
 function assertSize (size) {
   if (typeof size !== 'number') {


### PR DESCRIPTION
`Uint8Array` defined an unwritable `from` property, which causes overwritting operation after changing `Buffer.__proto__` fails and break script execution.

e.g. failing to assign ".from" property in **Chrome**:
![image](https://cloud.githubusercontent.com/assets/12392344/19960585/c127afcc-a1e8-11e6-8c66-33c1e3e2ff46.png)

When use `buffer` with webpack, everything after `Buffer.from = ...` just gone.

And e.g. failing to require `buffer` in **node@4**
![image](https://cloud.githubusercontent.com/assets/12392344/19960464/ec8ecebc-a1e7-11e6-8d31-d5d746a3fa06.png)

We should move "Buffer.from" assignment forward to avoid this error.

Note that this may not be reproducible on all browser. In some browsers (or node@6) `Uint8Array` doesn't have 'from', or defines a writable 'from' property.