### PR TITLE
Add slice for converting to ArrayBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,12 @@ var buffer = Buffer.from(arrayBuffer)
 To convert a `Buffer` to an `ArrayBuffer`, use the `.buffer` property (which is present on all `Uint8Array` objects):
 
 ```js
-var arrayBuffer = buffer.buffer
+var arrayBuffer = buffer.buffer.slice(
+  buffer.byteOffset, buffer.byteOffset + buffer.byteLength
+)
 ```
+
+Alternatively, use the [`to-arraybuffer`](https://www.npmjs.com/package/to-arraybuffer) module.
 
 ## performance
 


### PR DESCRIPTION
The .buffer property is an ArrayBuffer, but it is not necessarily the
same length as the original buffer. This adds further documentation to
the README to flesh out converting a Buffer to an ArrayBuffer.

It is based on [your answer here](https://stackoverflow.com/questions/8609289/convert-a-binary-nodejs-buffer-to-javascript-arraybuffer).