### PR TITLE
Sync upstream test-buffer-alloc

### DIFF
--- a/bin/download-node-tests.js
+++ b/bin/download-node-tests.js
@@ -71,15 +71,6 @@ function testfixer (filename) {
       firstline = false
     }
 
-    // use `var` instead of `const`/`let`
-    line = line.replace(/(const|let) /g, 'var ')
-
-    // make `var common = require('common')` work
-    line = line.replace(/(var common = require.*)/g, 'var common = { skip: function () {} };')
-
-    // make `require('../common')` work
-    line = line.replace(/require\('\.\.\/common'\);/g, '')
-
     // require browser buffer
     line = line.replace(/(.*)require\('buffer'\)(.*)/g, '$1require(\'../../\')$2')
 

--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@ function fromString (string, encoding) {
   }
 
   if (!Buffer.isEncoding(encoding)) {
-    throw new TypeError('"encoding" must be a valid string encoding')
+    throw new TypeError('Unknown encoding: ' + encoding)
   }
 
   var length = byteLength(string, encoding) | 0

--- a/index.js
+++ b/index.js
@@ -1462,7 +1462,7 @@ Buffer.prototype.copy = function copy (target, targetStart, start, end) {
   if (targetStart < 0) {
     throw new RangeError('targetStart out of bounds')
   }
-  if (start < 0 || start >= this.length) throw new RangeError('sourceStart out of bounds')
+  if (start < 0 || start >= this.length) throw new RangeError('Index out of range')
   if (end < 0) throw new RangeError('sourceEnd out of bounds')
 
   // Are we oob?

--- a/index.js
+++ b/index.js
@@ -53,6 +53,16 @@ function typedArraySupport () {
   }
 }
 
+Object.defineProperty(Buffer.prototype, 'offset', {
+  enumerable: true,
+  get () {
+    if (!(this instanceof Buffer)) {
+      return undefined
+    }
+    return this.byteOffset
+  }
+})
+
 function createBuffer (length) {
   if (length > K_MAX_LENGTH) {
     throw new RangeError('Invalid typed array length')

--- a/index.js
+++ b/index.js
@@ -1445,6 +1445,9 @@ Buffer.prototype.writeDoubleBE = function writeDoubleBE (value, offset, noAssert
 
 // copy(targetBuffer, targetStart=0, sourceStart=0, sourceEnd=buffer.length)
 Buffer.prototype.copy = function copy (target, targetStart, start, end) {
+  if (target === undefined) {
+    throw new TypeError('argument should be a Buffer')
+  }
   if (!start) start = 0
   if (!end && end !== 0) end = this.length
   if (targetStart >= target.length) targetStart = target.length

--- a/index.js
+++ b/index.js
@@ -1560,9 +1560,11 @@ Buffer.prototype.fill = function fill (val, start, end, encoding) {
 // HELPER FUNCTIONS
 // ================
 
-var INVALID_BASE64_RE = /[^+/0-9A-Za-z-_]/g
+var INVALID_BASE64_RE = /[^+/0-9A-Za-z-_=]/g
 
 function base64clean (str) {
+  // Node takes equal signs as end of the Base64 encoding
+  str = str.split('=')[0]
   // Node strips out invalid characters like \n and \t from the string, base64-js does not
   str = str.trim().replace(INVALID_BASE64_RE, '')
   // Node converts strings with length < 2 to ''

--- a/index.js
+++ b/index.js
@@ -1512,17 +1512,19 @@ Buffer.prototype.fill = function fill (val, start, end, encoding) {
       encoding = end
       end = this.length
     }
-    if (val.length === 1) {
-      var code = val.charCodeAt(0)
-      if (code < 256) {
-        val = code
-      }
-    }
     if (encoding !== undefined && typeof encoding !== 'string') {
       throw new TypeError('encoding must be a string')
     }
     if (typeof encoding === 'string' && !Buffer.isEncoding(encoding)) {
       throw new TypeError('Unknown encoding: ' + encoding)
+    }
+    if (val.length === 1) {
+      var code = val.charCodeAt(0)
+      if ((encoding === 'utf8' && code < 128) ||
+          encoding === 'latin1') {
+        // Fast path: If `val` fits into a single byte, use that numeric value.
+        val = code
+      }
     }
   } else if (typeof val === 'number') {
     val = val & 255

--- a/index.js
+++ b/index.js
@@ -532,6 +532,8 @@ Buffer.prototype.toString = function toString () {
   return slowToString.apply(this, arguments)
 }
 
+Buffer.prototype.toLocaleString = Buffer.prototype.toString
+
 Buffer.prototype.equals = function equals (b) {
   if (!Buffer.isBuffer(b)) throw new TypeError('Argument must be a Buffer')
   if (this === b) return true

--- a/index.js
+++ b/index.js
@@ -217,7 +217,7 @@ function fromArrayLike (array) {
 
 function fromArrayBuffer (array, byteOffset, length) {
   if (byteOffset < 0 || array.byteLength < byteOffset) {
-    throw new RangeError('\'offset\' is out of bounds')
+    throw new RangeError('"offset" is outside of buffer bounds')
   }
 
   if (array.byteLength < byteOffset + (length || 0)) {

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ function from (value, encodingOrOffset, length) {
     throw new TypeError('"value" argument must not be a number')
   }
 
-  if (isArrayBuffer(value)) {
+  if (isArrayBuffer(value) || (value && isArrayBuffer(value.buffer))) {
     return fromArrayBuffer(value, encodingOrOffset, length)
   }
 

--- a/index.js
+++ b/index.js
@@ -1552,6 +1552,10 @@ Buffer.prototype.fill = function fill (val, start, end, encoding) {
       ? val
       : new Buffer(val, encoding)
     var len = bytes.length
+    if (len === 0) {
+      throw new TypeError('The value "' + val +
+        '" is invalid for argument "value"')
+    }
     for (i = 0; i < end - start; ++i) {
       this[i + start] = bytes[i % len]
     }

--- a/index.js
+++ b/index.js
@@ -264,7 +264,7 @@ function fromObject (obj) {
     }
   }
 
-  throw new TypeError('First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object.')
+  throw new TypeError('The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object.')
 }
 
 function checked (length) {

--- a/index.js
+++ b/index.js
@@ -241,7 +241,7 @@ function fromArrayBuffer (array, byteOffset, length) {
   }
 
   if (array.byteLength < byteOffset + (length || 0)) {
-    throw new RangeError('\'length\' is out of bounds')
+    throw new RangeError('"length" is outside of buffer bounds')
   }
 
   var buf

--- a/index.js
+++ b/index.js
@@ -752,9 +752,7 @@ function hexWrite (buf, string, offset, length) {
     }
   }
 
-  // must be an even number of digits
   var strLen = string.length
-  if (strLen % 2 !== 0) throw new TypeError('Invalid hex string')
 
   if (length > strLen / 2) {
     length = strLen / 2

--- a/index.js
+++ b/index.js
@@ -53,6 +53,16 @@ function typedArraySupport () {
   }
 }
 
+Object.defineProperty(Buffer.prototype, 'parent', {
+  enumerable: true,
+  get () {
+    if (!(this instanceof Buffer)) {
+      return undefined
+    }
+    return this.buffer
+  }
+})
+
 Object.defineProperty(Buffer.prototype, 'offset', {
   enumerable: true,
   get () {

--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ Buffer.__proto__ = Uint8Array
 
 function assertSize (size) {
   if (typeof size !== 'number') {
-    throw new TypeError('"size" argument must be a number')
+    throw new TypeError('"size" argument must be of type number')
   } else if (size < 0) {
     throw new RangeError('"size" argument must not be negative')
   }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "standard": {
     "ignore": [
       "test/node/**/*.js",
+      "test/common.js",
       "test/_polyfill.js",
       "perf/**/*.js"
     ]

--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,136 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/* eslint-disable required-modules, crypto-check */
+'use strict';
+const assert = require('assert');
+const mustCallChecks = [];
+
+function runCallChecks(exitCode) {
+  if (exitCode !== 0) return;
+
+  const failed = mustCallChecks.filter(function(context) {
+    if ('minimum' in context) {
+      context.messageSegment = `at least ${context.minimum}`;
+      return context.actual < context.minimum;
+    } else {
+      context.messageSegment = `exactly ${context.exact}`;
+      return context.actual !== context.exact;
+    }
+  });
+
+  failed.forEach(function(context) {
+    console.log('Mismatched %s function calls. Expected %s, actual %d.',
+                context.name,
+                context.messageSegment,
+                context.actual);
+    console.log(context.stack.split('\n').slice(2).join('\n'));
+  });
+
+  if (failed.length) process.exit(1);
+}
+
+exports.mustCall = function(fn, exact) {
+  return _mustCallInner(fn, exact, 'exact');
+};
+
+function _mustCallInner(fn, criteria = 1, field) {
+  if (process._exiting)
+    throw new Error('Cannot use common.mustCall*() in process exit handler');
+  if (typeof fn === 'number') {
+    criteria = fn;
+    fn = noop;
+  } else if (fn === undefined) {
+    fn = noop;
+  }
+
+  if (typeof criteria !== 'number')
+    throw new TypeError(`Invalid ${field} value: ${criteria}`);
+
+  const context = {
+    [field]: criteria,
+    actual: 0,
+    stack: (new Error()).stack,
+    name: fn.name || '<anonymous>'
+  };
+
+  // add the exit listener only once to avoid listener leak warnings
+  if (mustCallChecks.length === 0) process.on('exit', runCallChecks);
+
+  mustCallChecks.push(context);
+
+  return function() {
+    context.actual++;
+    return fn.apply(this, arguments);
+  };
+}
+
+// Useful for testing expected internal/error objects
+exports.expectsError = function expectsError(fn, settings, exact) {
+  if (typeof fn !== 'function') {
+    exact = settings;
+    settings = fn;
+    fn = undefined;
+  }
+  function innerFn(error) {
+    if ('type' in settings) {
+      const type = settings.type;
+      if (type !== Error && !Error.isPrototypeOf(type)) {
+        throw new TypeError('`settings.type` must inherit from `Error`');
+      }
+      assert(error instanceof type,
+             `${error.name} is not instance of ${type.name}`);
+      let typeName = error.constructor.name;
+      if (typeName === 'NodeError' && type.name !== 'NodeError') {
+        typeName = Object.getPrototypeOf(error.constructor).name;
+      }
+      assert.strictEqual(typeName, type.name);
+    }
+    if ('message' in settings) {
+      const message = settings.message;
+      if (typeof message === 'string') {
+        assert.strictEqual(error.message, message);
+      } else {
+        assert(message.test(error.message),
+               `${error.message} does not match ${message}`);
+      }
+    }
+    if ('name' in settings) {
+      assert.strictEqual(error.name, settings.name);
+    }
+    if (error.constructor.name === 'AssertionError') {
+      ['generatedMessage', 'actual', 'expected', 'operator'].forEach((key) => {
+        if (key in settings) {
+          const actual = error[key];
+          const expected = settings[key];
+          assert.strictEqual(actual, expected,
+                             `${key}: expected ${expected}, not ${actual}`);
+        }
+      });
+    }
+    return true;
+  }
+  if (fn) {
+    assert.throws(fn, innerFn);
+    return;
+  }
+  return exports.mustCall(innerFn, exact);
+};

--- a/test/common.js
+++ b/test/common.js
@@ -83,6 +83,8 @@ function _mustCallInner(fn, criteria = 1, field) {
   };
 }
 
+exports.printSkipMessage = function(msg) {}
+
 // Useful for testing expected internal/error objects
 exports.expectsError = function expectsError(fn, settings, exact) {
   if (typeof fn !== 'function') {

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -935,11 +935,11 @@ var ps = Buffer.poolSize;
 Buffer.poolSize = 0;
 assert(Buffer.allocUnsafe(1).parent instanceof ArrayBuffer);
 Buffer.poolSize = ps;
-
+*/
 // Test Buffer.copy() segfault
 assert.throws(() => Buffer.allocUnsafe(10).copy(),
               /TypeError: argument should be a Buffer/);
-
+/*
 var regErrorMsg =
   new RegExp('The first argument must be one of type string, Buffer, ' +
              'ArrayBuffer, Array, or Array-like Object\\.');

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -29,7 +29,8 @@ assert.strictEqual(0, d.length);
 
 // Test offset properties
 {
-  var b = Buffer.alloc(128);
+  // NOTE vmx 2018-01-21: Without this `const` later tests will fail
+  const b = Buffer.alloc(128);
   assert.strictEqual(128, b.length);
   assert.strictEqual(0, b.byteOffset);
   assert.strictEqual(0, b.offset);
@@ -164,7 +165,7 @@ assert.doesNotThrow(() => Buffer.alloc(1).write('', 1, 0));
     assert.strictEqual(sliceA[i], sliceB[i]);
   }
 }
-/*
+
 {
   var slice = b.slice(100, 150);
   assert.strictEqual(50, slice.length);
@@ -172,7 +173,7 @@ assert.doesNotThrow(() => Buffer.alloc(1).write('', 1, 0));
     assert.strictEqual(b[100 + i], slice[i]);
   }
 }
-*/
+
 {
   // make sure only top level parent propagates from allocPool
   var b = Buffer.allocUnsafe(5);

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -915,7 +915,7 @@ common.expectsError(
     assert.strictEqual(c[i], i);
   }
 }
-/*
+
 if (common.hasCrypto) { // eslint-disable-line crypto-check
   // Test truncation after decode
   var crypto = require('crypto');
@@ -930,7 +930,7 @@ if (common.hasCrypto) { // eslint-disable-line crypto-check
 } else {
   common.printSkipMessage('missing crypto');
 }
-
+/*
 var ps = Buffer.poolSize;
 Buffer.poolSize = 0;
 assert(Buffer.allocUnsafe(1).parent instanceof ArrayBuffer);

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -1005,13 +1005,13 @@ assert.throws(() => Buffer.alloc({ valueOf: () => 1 }),
               /"size" argument must be of type number/);
 assert.throws(() => Buffer.alloc({ valueOf: () => -1 }),
               /"size" argument must be of type number/);
-/*
+
 assert.strictEqual(Buffer.prototype.toLocaleString, Buffer.prototype.toString);
 {
   var buf = Buffer.from('test');
   assert.strictEqual(buf.toLocaleString(), buf.toString());
 }
-
+/*
 common.expectsError(() => {
   Buffer.alloc(0x1000, 'This is not correctly encoded', 'hex');
 }, {

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -967,7 +967,7 @@ assert.strictEqual(SlowBuffer.prototype.offset, undefined);
   assert.doesNotThrow(() => Buffer.from('abc'));
 }
 
-/*
+
 // Test that ParseArrayIndex handles full uint32
 {
   var errMsg = common.expectsError({
@@ -977,7 +977,7 @@ assert.strictEqual(SlowBuffer.prototype.offset, undefined);
   });
   assert.throws(() => Buffer.from(new ArrayBuffer(0), -1 >>> 0), errMsg);
 }
-
+/*
 // ParseArrayIndex() should reject values that don't fit in a 32 bits size_t.
 common.expectsError(() => {
   var a = Buffer.alloc(1);

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -1011,25 +1011,25 @@ assert.strictEqual(Buffer.prototype.toLocaleString, Buffer.prototype.toString);
   var buf = Buffer.from('test');
   assert.strictEqual(buf.toLocaleString(), buf.toString());
 }
-/*
+
 common.expectsError(() => {
   Buffer.alloc(0x1000, 'This is not correctly encoded', 'hex');
 }, {
   code: 'ERR_INVALID_ARG_VALUE',
   type: TypeError
 });
-
+/*
 common.expectsError(() => {
   Buffer.alloc(0x1000, 'c', 'hex');
 }, {
   code: 'ERR_INVALID_ARG_VALUE',
   type: TypeError
 });
-
+*/
 common.expectsError(() => {
   Buffer.alloc(1, Buffer.alloc(0));
 }, {
   code: 'ERR_INVALID_ARG_VALUE',
   type: TypeError
 });
-*/
+

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -1,35 +1,34 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-var common = require('../common.js');
-var assert = require('assert');
-var vm = require('vm');
+const common = require('../common');
+const assert = require('assert');
+const vm = require('vm');
 
-var SlowBuffer = require('../../').SlowBuffer;
+const SlowBuffer = require('../../').SlowBuffer;
 
 
-var b = Buffer.allocUnsafe(1024);
+const b = Buffer.allocUnsafe(1024);
 assert.strictEqual(1024, b.length);
 
 b[0] = -1;
 assert.strictEqual(b[0], 255);
 
-for (var i = 0; i < 1024; i++) {
+for (let i = 0; i < 1024; i++) {
   b[i] = i % 256;
 }
 
-for (var i = 0; i < 1024; i++) {
+for (let i = 0; i < 1024; i++) {
   assert.strictEqual(i % 256, b[i]);
 }
 
-var c = Buffer.allocUnsafe(512);
+const c = Buffer.allocUnsafe(512);
 assert.strictEqual(512, c.length);
 
-var d = Buffer.from([]);
+const d = Buffer.from([]);
 assert.strictEqual(0, d.length);
 
 // Test offset properties
 {
-  // NOTE vmx 2018-01-21: Without this `const` later tests will fail
   const b = Buffer.alloc(128);
   assert.strictEqual(128, b.length);
   assert.strictEqual(0, b.byteOffset);
@@ -38,17 +37,17 @@ assert.strictEqual(0, d.length);
 
 // Test creating a Buffer from a Uint32Array
 {
-  var ui32 = new Uint32Array(4).fill(42);
-  var e = Buffer.from(ui32);
-  for (var [index, value] of e.entries()) {
+  const ui32 = new Uint32Array(4).fill(42);
+  const e = Buffer.from(ui32);
+  for (const [index, value] of e.entries()) {
     assert.strictEqual(value, ui32[index]);
   }
 }
 // Test creating a Buffer from a Uint32Array (old constructor)
 {
-  var ui32 = new Uint32Array(4).fill(42);
-  var e = Buffer(ui32);
-  for (var [key, value] of e.entries()) {
+  const ui32 = new Uint32Array(4).fill(42);
+  const e = Buffer(ui32);
+  for (const [key, value] of e.entries()) {
     assert.deepStrictEqual(value, ui32[key]);
   }
 }
@@ -100,7 +99,7 @@ b.copy(Buffer.alloc(1), 0, 2048, 2048);
 
 // testing for smart defaults and ability to pass string values as offset
 {
-  var writeTest = Buffer.from('abcdes');
+  const writeTest = Buffer.from('abcdes');
   writeTest.write('n', 'ascii');
   writeTest.write('o', '1', 'ascii');
   writeTest.write('d', '2', 'ascii');
@@ -115,42 +114,42 @@ assert.doesNotThrow(() => Buffer.alloc(1).write('', 1, 0));
 
 // ASCII slice test
 {
-  var asciiString = 'hello world';
+  const asciiString = 'hello world';
 
-  for (var i = 0; i < asciiString.length; i++) {
+  for (let i = 0; i < asciiString.length; i++) {
     b[i] = asciiString.charCodeAt(i);
   }
-  var asciiSlice = b.toString('ascii', 0, asciiString.length);
+  const asciiSlice = b.toString('ascii', 0, asciiString.length);
   assert.strictEqual(asciiString, asciiSlice);
 }
 
 {
-  var asciiString = 'hello world';
-  var offset = 100;
+  const asciiString = 'hello world';
+  const offset = 100;
 
   assert.strictEqual(asciiString.length, b.write(asciiString, offset, 'ascii'));
-  var asciiSlice = b.toString('ascii', offset, offset + asciiString.length);
+  const asciiSlice = b.toString('ascii', offset, offset + asciiString.length);
   assert.strictEqual(asciiString, asciiSlice);
 }
 
 {
-  var asciiString = 'hello world';
-  var offset = 100;
+  const asciiString = 'hello world';
+  const offset = 100;
 
-  var sliceA = b.slice(offset, offset + asciiString.length);
-  var sliceB = b.slice(offset, offset + asciiString.length);
-  for (var i = 0; i < asciiString.length; i++) {
+  const sliceA = b.slice(offset, offset + asciiString.length);
+  const sliceB = b.slice(offset, offset + asciiString.length);
+  for (let i = 0; i < asciiString.length; i++) {
     assert.strictEqual(sliceA[i], sliceB[i]);
   }
 }
 
 // UTF-8 slice test
 {
-  var utf8String = '¡hέlló wôrld!';
-  var offset = 100;
+  const utf8String = '¡hέlló wôrld!';
+  const offset = 100;
 
   b.write(utf8String, 0, Buffer.byteLength(utf8String), 'utf8');
-  var utf8Slice = b.toString('utf8', 0, Buffer.byteLength(utf8String));
+  let utf8Slice = b.toString('utf8', 0, Buffer.byteLength(utf8String));
   assert.strictEqual(utf8String, utf8Slice);
 
   assert.strictEqual(Buffer.byteLength(utf8String),
@@ -159,63 +158,63 @@ assert.doesNotThrow(() => Buffer.alloc(1).write('', 1, 0));
                          offset + Buffer.byteLength(utf8String));
   assert.strictEqual(utf8String, utf8Slice);
 
-  var sliceA = b.slice(offset, offset + Buffer.byteLength(utf8String));
-  var sliceB = b.slice(offset, offset + Buffer.byteLength(utf8String));
-  for (var i = 0; i < Buffer.byteLength(utf8String); i++) {
+  const sliceA = b.slice(offset, offset + Buffer.byteLength(utf8String));
+  const sliceB = b.slice(offset, offset + Buffer.byteLength(utf8String));
+  for (let i = 0; i < Buffer.byteLength(utf8String); i++) {
     assert.strictEqual(sliceA[i], sliceB[i]);
   }
 }
 
 {
-  var slice = b.slice(100, 150);
+  const slice = b.slice(100, 150);
   assert.strictEqual(50, slice.length);
-  for (var i = 0; i < 50; i++) {
+  for (let i = 0; i < 50; i++) {
     assert.strictEqual(b[100 + i], slice[i]);
   }
 }
 
 {
   // make sure only top level parent propagates from allocPool
-  var b = Buffer.allocUnsafe(5);
-  var c = b.slice(0, 4);
-  var d = c.slice(0, 2);
+  const b = Buffer.allocUnsafe(5);
+  const c = b.slice(0, 4);
+  const d = c.slice(0, 2);
   assert.strictEqual(b.parent, c.parent);
   assert.strictEqual(b.parent, d.parent);
 }
 
 {
   // also from a non-pooled instance
-  var b = Buffer.allocUnsafeSlow(5);
-  var c = b.slice(0, 4);
-  var d = c.slice(0, 2);
+  const b = Buffer.allocUnsafeSlow(5);
+  const c = b.slice(0, 4);
+  const d = c.slice(0, 2);
   assert.strictEqual(c.parent, d.parent);
 }
 
 {
   // Bug regression test
-  var testValue = '\u00F6\u65E5\u672C\u8A9E'; // ö日本語
-  var buffer = Buffer.allocUnsafe(32);
-  var size = buffer.write(testValue, 0, 'utf8');
-  var slice = buffer.toString('utf8', 0, size);
+  const testValue = '\u00F6\u65E5\u672C\u8A9E'; // ö日本語
+  const buffer = Buffer.allocUnsafe(32);
+  const size = buffer.write(testValue, 0, 'utf8');
+  const slice = buffer.toString('utf8', 0, size);
   assert.strictEqual(slice, testValue);
 }
 
 {
   // Test triple  slice
-  var a = Buffer.allocUnsafe(8);
-  for (var i = 0; i < 8; i++) a[i] = i;
-  var b = a.slice(4, 8);
+  const a = Buffer.allocUnsafe(8);
+  for (let i = 0; i < 8; i++) a[i] = i;
+  const b = a.slice(4, 8);
   assert.strictEqual(4, b[0]);
   assert.strictEqual(5, b[1]);
   assert.strictEqual(6, b[2]);
   assert.strictEqual(7, b[3]);
-  var c = b.slice(2, 4);
+  const c = b.slice(2, 4);
   assert.strictEqual(6, c[0]);
   assert.strictEqual(7, c[1]);
 }
 
 {
-  var d = Buffer.from([23, 42, 255]);
+  const d = Buffer.from([23, 42, 255]);
   assert.strictEqual(d.length, 3);
   assert.strictEqual(d[0], 23);
   assert.strictEqual(d[1], 42);
@@ -225,26 +224,26 @@ assert.doesNotThrow(() => Buffer.alloc(1).write('', 1, 0));
 
 {
   // Test for proper UTF-8 Encoding
-  var e = Buffer.from('über');
+  const e = Buffer.from('über');
   assert.deepStrictEqual(e, Buffer.from([195, 188, 98, 101, 114]));
 }
 
 {
   // Test for proper ascii Encoding, length should be 4
-  var f = Buffer.from('über', 'ascii');
+  const f = Buffer.from('über', 'ascii');
   assert.deepStrictEqual(f, Buffer.from([252, 98, 101, 114]));
 }
 
 ['ucs2', 'ucs-2', 'utf16le', 'utf-16le'].forEach((encoding) => {
   {
     // Test for proper UTF16LE encoding, length should be 8
-    var f = Buffer.from('über', encoding);
+    const f = Buffer.from('über', encoding);
     assert.deepStrictEqual(f, Buffer.from([252, 0, 98, 0, 101, 0, 114, 0]));
   }
 
   {
     // Length should be 12
-    var f = Buffer.from('привет', encoding);
+    const f = Buffer.from('привет', encoding);
     assert.deepStrictEqual(
       f, Buffer.from([63, 4, 64, 4, 56, 4, 50, 4, 53, 4, 66, 4])
     );
@@ -252,26 +251,26 @@ assert.doesNotThrow(() => Buffer.alloc(1).write('', 1, 0));
   }
 
   {
-    var f = Buffer.from([0, 0, 0, 0, 0]);
+    const f = Buffer.from([0, 0, 0, 0, 0]);
     assert.strictEqual(f.length, 5);
-    var size = f.write('あいうえお', encoding);
+    const size = f.write('あいうえお', encoding);
     assert.strictEqual(size, 4);
     assert.deepStrictEqual(f, Buffer.from([0x42, 0x30, 0x44, 0x30, 0x00]));
   }
 });
 
 {
-  var f = Buffer.from('\uD83D\uDC4D', 'utf-16le'); // THUMBS UP SIGN (U+1F44D)
+  const f = Buffer.from('\uD83D\uDC4D', 'utf-16le'); // THUMBS UP SIGN (U+1F44D)
   assert.strictEqual(f.length, 4);
   assert.deepStrictEqual(f, Buffer.from('3DD84DDC', 'hex'));
 }
 
 // Test construction from arrayish object
 {
-  var arrayIsh = { 0: 0, 1: 1, 2: 2, 3: 3, length: 4 };
-  var g = Buffer.from(arrayIsh);
+  const arrayIsh = { 0: 0, 1: 1, 2: 2, 3: 3, length: 4 };
+  let g = Buffer.from(arrayIsh);
   assert.deepStrictEqual(g, Buffer.from([0, 1, 2, 3]));
-  var strArrayIsh = { 0: '0', 1: '1', 2: '2', 3: '3', length: 4 };
+  const strArrayIsh = { 0: '0', 1: '1', 2: '2', 3: '3', length: 4 };
   g = Buffer.from(strArrayIsh);
   assert.deepStrictEqual(g, Buffer.from([0, 1, 2, 3]));
 }
@@ -283,7 +282,7 @@ assert.strictEqual('TWFu', (Buffer.from('Man')).toString('base64'));
 
 {
   // test that regular and URL-safe base64 both work
-  var expected = [0xff, 0xff, 0xbe, 0xff, 0xef, 0xbf, 0xfb, 0xef, 0xff];
+  const expected = [0xff, 0xff, 0xbe, 0xff, 0xef, 0xbf, 0xfb, 0xef, 0xff];
   assert.deepStrictEqual(Buffer.from('//++/++/++//', 'base64'),
                          Buffer.from(expected));
   assert.deepStrictEqual(Buffer.from('__--_--_--__', 'base64'),
@@ -292,12 +291,12 @@ assert.strictEqual('TWFu', (Buffer.from('Man')).toString('base64'));
 
 {
   // big example
-  var quote = 'Man is distinguished, not only by his reason, but by this ' +
+  const quote = 'Man is distinguished, not only by his reason, but by this ' +
                 'singular passion from other animals, which is a lust ' +
                 'of the mind, that by a perseverance of delight in the ' +
                 'continued and indefatigable generation of knowledge, ' +
                 'exceeds the short vehemence of any carnal pleasure.';
-  var expected = 'TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb' +
+  const expected = 'TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb' +
                    '24sIGJ1dCBieSB0aGlzIHNpbmd1bGFyIHBhc3Npb24gZnJvbSBvdGhlci' +
                    'BhbmltYWxzLCB3aGljaCBpcyBhIGx1c3Qgb2YgdGhlIG1pbmQsIHRoYXQ' +
                    'gYnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0aGUgY29udGlu' +
@@ -306,13 +305,13 @@ assert.strictEqual('TWFu', (Buffer.from('Man')).toString('base64'));
                    '5hbCBwbGVhc3VyZS4=';
   assert.strictEqual(expected, (Buffer.from(quote)).toString('base64'));
 
-  var b = Buffer.allocUnsafe(1024);
-  var bytesWritten = b.write(expected, 0, 'base64');
+  let b = Buffer.allocUnsafe(1024);
+  let bytesWritten = b.write(expected, 0, 'base64');
   assert.strictEqual(quote.length, bytesWritten);
   assert.strictEqual(quote, b.toString('ascii', 0, quote.length));
 
   // check that the base64 decoder ignores whitespace
-  var expectedWhite = `${expected.slice(0, 60)} \n` +
+  const expectedWhite = `${expected.slice(0, 60)} \n` +
                         `${expected.slice(60, 120)} \n` +
                         `${expected.slice(120, 180)} \n` +
                         `${expected.slice(180, 240)} \n` +
@@ -330,7 +329,7 @@ assert.strictEqual('TWFu', (Buffer.from('Man')).toString('base64'));
   assert.strictEqual(quote, b.toString('ascii', 0, quote.length));
 
   // check that the base64 decoder ignores illegal chars
-  var expectedIllegal = expected.slice(0, 60) + ' \x80' +
+  const expectedIllegal = expected.slice(0, 60) + ' \x80' +
                           expected.slice(60, 120) + ' \xff' +
                           expected.slice(120, 180) + ' \x00' +
                           expected.slice(180, 240) + ' \x98' +
@@ -438,7 +437,7 @@ assert.strictEqual(
 
 {
 // This string encodes single '.' character in UTF-16
-  var dot = Buffer.from('//4uAA==', 'base64');
+  const dot = Buffer.from('//4uAA==', 'base64');
   assert.strictEqual(dot[0], 0xff);
   assert.strictEqual(dot[1], 0xfe);
   assert.strictEqual(dot[2], 0x2e);
@@ -450,11 +449,11 @@ assert.strictEqual(
   // Writing base64 at a position > 0 should not mangle the result.
   //
   // https://github.com/joyent/node/issues/402
-  var segments = ['TWFkbmVzcz8h', 'IFRoaXM=', 'IGlz', 'IG5vZGUuanMh'];
-  var b = Buffer.allocUnsafe(64);
-  var pos = 0;
+  const segments = ['TWFkbmVzcz8h', 'IFRoaXM=', 'IGlz', 'IG5vZGUuanMh'];
+  const b = Buffer.allocUnsafe(64);
+  let pos = 0;
 
-  for (var i = 0; i < segments.length; ++i) {
+  for (let i = 0; i < segments.length; ++i) {
     pos += b.write(segments[i], pos, 'base64');
   }
   assert.strictEqual(b.toString('latin1', 0, pos),
@@ -474,26 +473,26 @@ assert.deepStrictEqual(Buffer.from(' YWJvcnVtLg', 'base64'),
 
 {
   // Creating buffers larger than pool size.
-  var l = Buffer.poolSize + 5;
-  var s = 'h'.repeat(l);
-  var b = Buffer.from(s);
+  const l = Buffer.poolSize + 5;
+  const s = 'h'.repeat(l);
+  const b = Buffer.from(s);
 
-  for (var i = 0; i < l; i++) {
+  for (let i = 0; i < l; i++) {
     assert.strictEqual('h'.charCodeAt(0), b[i]);
   }
 
-  var sb = b.toString();
+  const sb = b.toString();
   assert.strictEqual(sb.length, s.length);
   assert.strictEqual(sb, s);
 }
 
 {
   // test hex toString
-  var hexb = Buffer.allocUnsafe(256);
-  for (var i = 0; i < 256; i++) {
+  const hexb = Buffer.allocUnsafe(256);
+  for (let i = 0; i < 256; i++) {
     hexb[i] = i;
   }
-  var hexStr = hexb.toString('hex');
+  const hexStr = hexb.toString('hex');
   assert.strictEqual(hexStr,
                      '000102030405060708090a0b0c0d0e0f' +
                      '101112131415161718191a1b1c1d1e1f' +
@@ -512,8 +511,8 @@ assert.deepStrictEqual(Buffer.from(' YWJvcnVtLg', 'base64'),
                      'e0e1e2e3e4e5e6e7e8e9eaebecedeeef' +
                      'f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff');
 
-  var hexb2 = Buffer.from(hexStr, 'hex');
-  for (var i = 0; i < 256; i++) {
+  const hexb2 = Buffer.from(hexStr, 'hex');
+  for (let i = 0; i < 256; i++) {
     assert.strictEqual(hexb2[i], hexb[i]);
   }
 }
@@ -530,29 +529,29 @@ assert.strictEqual(Buffer.from('A', 'base64').length, 0);
 
 {
   // test an invalid slice end.
-  var b = Buffer.from([1, 2, 3, 4, 5]);
-  var b2 = b.toString('hex', 1, 10000);
-  var b3 = b.toString('hex', 1, 5);
-  var b4 = b.toString('hex', 1);
+  const b = Buffer.from([1, 2, 3, 4, 5]);
+  const b2 = b.toString('hex', 1, 10000);
+  const b3 = b.toString('hex', 1, 5);
+  const b4 = b.toString('hex', 1);
   assert.strictEqual(b2, b3);
   assert.strictEqual(b2, b4);
 }
 
 function buildBuffer(data) {
   if (Array.isArray(data)) {
-    var buffer = Buffer.allocUnsafe(data.length);
+    const buffer = Buffer.allocUnsafe(data.length);
     data.forEach((v, k) => buffer[k] = v);
     return buffer;
   }
   return null;
 }
 
-var x = buildBuffer([0x81, 0xa3, 0x66, 0x6f, 0x6f, 0xa3, 0x62, 0x61, 0x72]);
+const x = buildBuffer([0x81, 0xa3, 0x66, 0x6f, 0x6f, 0xa3, 0x62, 0x61, 0x72]);
 
 assert.strictEqual('<Buffer 81 a3 66 6f 6f a3 62 61 72>', x.inspect());
 
 {
-  var z = x.slice(4);
+  const z = x.slice(4);
   assert.strictEqual(5, z.length);
   assert.strictEqual(0x6f, z[0]);
   assert.strictEqual(0xa3, z[1]);
@@ -562,51 +561,51 @@ assert.strictEqual('<Buffer 81 a3 66 6f 6f a3 62 61 72>', x.inspect());
 }
 
 {
-  var z = x.slice(0);
+  const z = x.slice(0);
   assert.strictEqual(z.length, x.length);
 }
 
 {
-  var z = x.slice(0, 4);
+  const z = x.slice(0, 4);
   assert.strictEqual(4, z.length);
   assert.strictEqual(0x81, z[0]);
   assert.strictEqual(0xa3, z[1]);
 }
 
 {
-  var z = x.slice(0, 9);
+  const z = x.slice(0, 9);
   assert.strictEqual(9, z.length);
 }
 
 {
-  var z = x.slice(1, 4);
+  const z = x.slice(1, 4);
   assert.strictEqual(3, z.length);
   assert.strictEqual(0xa3, z[0]);
 }
 
 {
-  var z = x.slice(2, 4);
+  const z = x.slice(2, 4);
   assert.strictEqual(2, z.length);
   assert.strictEqual(0x66, z[0]);
   assert.strictEqual(0x6f, z[1]);
 }
 
 ['ucs2', 'ucs-2', 'utf16le', 'utf-16le'].forEach((encoding) => {
-  var b = Buffer.allocUnsafe(10);
+  const b = Buffer.allocUnsafe(10);
   b.write('あいうえお', encoding);
   assert.strictEqual(b.toString(encoding), 'あいうえお');
 });
 
 ['ucs2', 'ucs-2', 'utf16le', 'utf-16le'].forEach((encoding) => {
-  var b = Buffer.allocUnsafe(11);
+  const b = Buffer.allocUnsafe(11);
   b.write('あいうえお', 1, encoding);
   assert.strictEqual(b.toString(encoding, 1), 'あいうえお');
 });
 
 {
   // latin1 encoding should write only one byte per character.
-  var b = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
-  var s = String.fromCharCode(0xffff);
+  const b = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
+  let s = String.fromCharCode(0xffff);
   b.write(s, 0, 'latin1');
   assert.strictEqual(0xff, b[0]);
   assert.strictEqual(0xad, b[1]);
@@ -622,8 +621,8 @@ assert.strictEqual('<Buffer 81 a3 66 6f 6f a3 62 61 72>', x.inspect());
 
 {
   // Binary encoding should write only one byte per character.
-  var b = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
-  var s = String.fromCharCode(0xffff);
+  const b = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
+  let s = String.fromCharCode(0xffff);
   b.write(s, 0, 'latin1');
   assert.strictEqual(0xff, b[0]);
   assert.strictEqual(0xad, b[1]);
@@ -640,14 +639,14 @@ assert.strictEqual('<Buffer 81 a3 66 6f 6f a3 62 61 72>', x.inspect());
 {
   // https://github.com/nodejs/node-v0.x-archive/pull/1210
   // Test UTF-8 string includes null character
-  var buf = Buffer.from('\0');
+  let buf = Buffer.from('\0');
   assert.strictEqual(buf.length, 1);
   buf = Buffer.from('\0\0');
   assert.strictEqual(buf.length, 2);
 }
 
 {
-  var buf = Buffer.allocUnsafe(2);
+  const buf = Buffer.allocUnsafe(2);
   assert.strictEqual(buf.write(''), 0); //0bytes
   assert.strictEqual(buf.write('\0'), 1); // 1byte (v8 adds null terminator)
   assert.strictEqual(buf.write('a\0'), 2); // 1byte * 2
@@ -657,7 +656,7 @@ assert.strictEqual('<Buffer 81 a3 66 6f 6f a3 62 61 72>', x.inspect());
 }
 
 {
-  var buf = Buffer.allocUnsafe(10);
+  const buf = Buffer.allocUnsafe(10);
   assert.strictEqual(buf.write('あいう'), 9); // 3bytes * 3 (v8 adds null term.)
   assert.strictEqual(buf.write('あいう\0'), 10); // 3bytes * 3 + 1byte
 }
@@ -665,7 +664,7 @@ assert.strictEqual('<Buffer 81 a3 66 6f 6f a3 62 61 72>', x.inspect());
 {
   // https://github.com/nodejs/node-v0.x-archive/issues/243
   // Test write() with maxLength
-  var buf = Buffer.allocUnsafe(4);
+  const buf = Buffer.allocUnsafe(4);
   buf.fill(0xFF);
   assert.strictEqual(buf.write('abcd', 1, 2, 'utf8'), 2);
   assert.strictEqual(buf[0], 0xFF);
@@ -706,7 +705,7 @@ assert.strictEqual('<Buffer 81 a3 66 6f 6f a3 62 61 72>', x.inspect());
 
 {
   // test offset returns are correct
-  var b = Buffer.allocUnsafe(16);
+  const b = Buffer.allocUnsafe(16);
   assert.strictEqual(4, b.writeUInt32LE(0, 0));
   assert.strictEqual(6, b.writeUInt16LE(0, 4));
   assert.strictEqual(7, b.writeUInt8(0, 6));
@@ -718,7 +717,7 @@ assert.strictEqual('<Buffer 81 a3 66 6f 6f a3 62 61 72>', x.inspect());
   // test unmatched surrogates not producing invalid utf8 output
   // ef bf bd = utf-8 representation of unicode replacement character
   // see https://codereview.chromium.org/121173009/
-  var buf = Buffer.from('ab\ud800cd', 'utf8');
+  const buf = Buffer.from('ab\ud800cd', 'utf8');
   assert.strictEqual(buf[0], 0x61);
   assert.strictEqual(buf[1], 0x62);
   assert.strictEqual(buf[2], 0xef);
@@ -730,8 +729,8 @@ assert.strictEqual('<Buffer 81 a3 66 6f 6f a3 62 61 72>', x.inspect());
 
 {
   // test for buffer overrun
-  var buf = Buffer.from([0, 0, 0, 0, 0]); // length: 5
-  var sub = buf.slice(0, 4);         // length: 4
+  const buf = Buffer.from([0, 0, 0, 0, 0]); // length: 5
+  const sub = buf.slice(0, 4);         // length: 4
   assert.strictEqual(sub.write('12345', 'latin1'), 4);
   assert.strictEqual(buf[4], 0);
   assert.strictEqual(sub.write('12345', 'binary'), 4);
@@ -740,7 +739,7 @@ assert.strictEqual('<Buffer 81 a3 66 6f 6f a3 62 61 72>', x.inspect());
 
 {
   // test alloc with fill option
-  var buf = Buffer.alloc(5, '800A', 'hex');
+  const buf = Buffer.alloc(5, '800A', 'hex');
   assert.strictEqual(buf[0], 128);
   assert.strictEqual(buf[1], 10);
   assert.strictEqual(buf[2], 128);
@@ -772,8 +771,8 @@ assert.strictEqual(Buffer.from('13.37').length, 5);
 
 {
   // Regression test, guard against buffer overrun in the base64 decoder.
-  var a = Buffer.allocUnsafe(3);
-  var b = Buffer.from('xxx');
+  const a = Buffer.allocUnsafe(3);
+  const b = Buffer.from('xxx');
   a.write('aaaaaaaa', 'base64');
   assert.strictEqual(b.toString(), 'xxx');
 }
@@ -799,7 +798,7 @@ assert.throws(() => Buffer.allocUnsafe(8).writeFloatLE(0.0, -1), RangeError);
 
 // test for common write(U)IntLE/BE
 {
-  var buf = Buffer.allocUnsafe(3);
+  let buf = Buffer.allocUnsafe(3);
   buf.writeUIntLE(0x123456, 0, 3);
   assert.deepStrictEqual(buf.toJSON().data, [0x56, 0x34, 0x12]);
   assert.strictEqual(buf.readUIntLE(0, 3), 0x123456);
@@ -905,12 +904,12 @@ common.expectsError(
 // Constructing a buffer from another buffer should a) work, and b) not corrupt
 // the source buffer.
 {
-  var a = [...Array(128).keys()]; // [0, 1, 2, 3, ... 126, 127]
-  var b = Buffer.from(a);
-  var c = Buffer.from(b);
+  const a = [...Array(128).keys()]; // [0, 1, 2, 3, ... 126, 127]
+  const b = Buffer.from(a);
+  const c = Buffer.from(b);
   assert.strictEqual(b.length, a.length);
   assert.strictEqual(c.length, a.length);
-  for (var i = 0, k = a.length; i < k; ++i) {
+  for (let i = 0, k = a.length; i < k; ++i) {
     assert.strictEqual(a[i], i);
     assert.strictEqual(b[i], i);
     assert.strictEqual(c[i], i);
@@ -919,10 +918,10 @@ common.expectsError(
 
 if (common.hasCrypto) { // eslint-disable-line crypto-check
   // Test truncation after decode
-  var crypto = require('crypto');
+  const crypto = require('crypto');
 
-  var b1 = Buffer.from('YW55=======', 'base64');
-  var b2 = Buffer.from('YW55', 'base64');
+  const b1 = Buffer.from('YW55=======', 'base64');
+  const b2 = Buffer.from('YW55', 'base64');
 
   assert.strictEqual(
     crypto.createHash('sha1').update(b1).digest('hex'),
@@ -932,7 +931,7 @@ if (common.hasCrypto) { // eslint-disable-line crypto-check
   common.printSkipMessage('missing crypto');
 }
 
-var ps = Buffer.poolSize;
+const ps = Buffer.poolSize;
 Buffer.poolSize = 0;
 assert(Buffer.allocUnsafe(1).parent instanceof ArrayBuffer);
 Buffer.poolSize = ps;
@@ -941,7 +940,7 @@ Buffer.poolSize = ps;
 assert.throws(() => Buffer.allocUnsafe(10).copy(),
               /TypeError: argument should be a Buffer/);
 
-var regErrorMsg =
+const regErrorMsg =
   new RegExp('The first argument must be one of type string, Buffer, ' +
              'ArrayBuffer, Array, or Array-like Object\\.');
 
@@ -971,7 +970,7 @@ assert.strictEqual(SlowBuffer.prototype.offset, undefined);
 
 // Test that ParseArrayIndex handles full uint32
 {
-  var errMsg = common.expectsError({
+  const errMsg = common.expectsError({
     code: 'ERR_BUFFER_OUT_OF_BOUNDS',
     type: RangeError,
     message: '"offset" is outside of buffer bounds'
@@ -981,14 +980,14 @@ assert.strictEqual(SlowBuffer.prototype.offset, undefined);
 
 // ParseArrayIndex() should reject values that don't fit in a 32 bits size_t.
 common.expectsError(() => {
-  var a = Buffer.alloc(1);
-  var b = Buffer.alloc(1);
+  const a = Buffer.alloc(1);
+  const b = Buffer.alloc(1);
   a.copy(b, 0, 0x100000000, 0x100000001);
 }, { code: undefined, type: RangeError, message: 'Index out of range' });
 
 // Unpooled buffer (replaces SlowBuffer)
 {
-  var ubuf = Buffer.allocUnsafeSlow(10);
+  const ubuf = Buffer.allocUnsafeSlow(10);
   assert(ubuf);
   assert(ubuf.buffer);
   assert.strictEqual(ubuf.buffer.byteLength, 10);
@@ -998,7 +997,7 @@ common.expectsError(() => {
 assert.doesNotThrow(() => Buffer.from(new ArrayBuffer()));
 
 // Test that ArrayBuffer from a different context is detected correctly
-var arrayBuf = vm.runInNewContext('new ArrayBuffer()');
+const arrayBuf = vm.runInNewContext('new ArrayBuffer()');
 assert.doesNotThrow(() => Buffer.from(arrayBuf));
 assert.doesNotThrow(() => Buffer.from({ buffer: arrayBuf }));
 
@@ -1009,7 +1008,7 @@ assert.throws(() => Buffer.alloc({ valueOf: () => -1 }),
 
 assert.strictEqual(Buffer.prototype.toLocaleString, Buffer.prototype.toString);
 {
-  var buf = Buffer.from('test');
+  const buf = Buffer.from('test');
   assert.strictEqual(buf.toLocaleString(), buf.toString());
 }
 

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -999,9 +999,8 @@ assert.doesNotThrow(() => Buffer.from(new ArrayBuffer()));
 // Test that ArrayBuffer from a different context is detected correctly
 var arrayBuf = vm.runInNewContext('new ArrayBuffer()');
 assert.doesNotThrow(() => Buffer.from(arrayBuf));
-/*
 assert.doesNotThrow(() => Buffer.from({ buffer: arrayBuf }));
-
+/*
 assert.throws(() => Buffer.alloc({ valueOf: () => 1 }),
               /"size" argument must be of type number/);
 assert.throws(() => Buffer.alloc({ valueOf: () => -1 }),

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -1,17 +1,13 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-
 var common = { skip: function () {} };
 var assert = require('assert');
+var vm = require('vm');
 
-var Buffer = require('../../').Buffer;
+var SlowBuffer = require('../../').SlowBuffer;
 
-// counter to ensure unique value is always copied
-var cntr = 0;
 
 var b = Buffer.allocUnsafe(1024);
-
-// console.log('b.length == %d', b.length);
 assert.strictEqual(1024, b.length);
 
 b[0] = -1;
@@ -26,240 +22,70 @@ for (var i = 0; i < 1024; i++) {
 }
 
 var c = Buffer.allocUnsafe(512);
-// console.log('c.length == %d', c.length);
 assert.strictEqual(512, c.length);
 
 var d = Buffer.from([]);
 assert.strictEqual(0, d.length);
 
-var ui32 = new Uint32Array(4).fill(42);
-var e = Buffer.from(ui32);
-for (var [index, value] of e.entries()) {
-  assert.strictEqual(value, ui32[index]);
+// Test offset properties
+{
+  var b = Buffer.alloc(128);
+  assert.strictEqual(128, b.length);
+  assert.strictEqual(0, b.byteOffset);
+  //assert.strictEqual(0, b.offset);
 }
 
-// First check Buffer#fill() works as expected.
-
-assert.throws(function() {
-  Buffer.allocUnsafe(8).fill('a', -1);
-});
-
-assert.throws(function() {
-  Buffer.allocUnsafe(8).fill('a', 0, 9);
-});
-
-// Make sure this doesn't hang indefinitely.
-Buffer.allocUnsafe(8).fill('');
-Buffer.alloc(8, '');
-
+// Test creating a Buffer from a Uint32Array
 {
-  var buf = Buffer.alloc(64, 10);
-  for (var i = 0; i < buf.length; i++)
-    assert.equal(buf[i], 10);
-
-  buf.fill(11, 0, buf.length >> 1);
-  for (var i = 0; i < buf.length >> 1; i++)
-    assert.equal(buf[i], 11);
-  for (var i = (buf.length >> 1) + 1; i < buf.length; i++)
-    assert.equal(buf[i], 10);
-
-  buf.fill('h');
-  for (var i = 0; i < buf.length; i++)
-    assert.equal('h'.charCodeAt(0), buf[i]);
-
-  buf.fill(0);
-  for (var i = 0; i < buf.length; i++)
-    assert.equal(0, buf[i]);
-
-  buf.fill(null);
-  for (var i = 0; i < buf.length; i++)
-    assert.equal(0, buf[i]);
-
-  buf.fill(1, 16, 32);
-  for (var i = 0; i < 16; i++)
-    assert.equal(0, buf[i]);
-  for (var i = 16; i < 32; i++)
-    assert.equal(1, buf[i]);
-  for (var i = 32; i < buf.length; i++)
-    assert.equal(0, buf[i]);
+  var ui32 = new Uint32Array(4).fill(42);
+  var e = Buffer.from(ui32);
+  for (var [index, value] of e.entries()) {
+    assert.strictEqual(value, ui32[index]);
+  }
 }
-
+// Test creating a Buffer from a Uint32Array (old constructor)
 {
-  var buf = Buffer.alloc(10, 'abc');
-  assert.equal(buf.toString(), 'abcabcabca');
-  buf.fill('է');
-  assert.equal(buf.toString(), 'էէէէէ');
-}
-
-{
-  // copy 512 bytes, from 0 to 512.
-  b.fill(++cntr);
-  c.fill(++cntr);
-  var copied = b.copy(c, 0, 0, 512);
-//   console.log('copied %d bytes from b into c', copied);
-  assert.strictEqual(512, copied);
-  for (var i = 0; i < c.length; i++) {
-    assert.strictEqual(b[i], c[i]);
+  var ui32 = new Uint32Array(4).fill(42);
+  var e = Buffer(ui32);
+  for (var [key, value] of e.entries()) {
+    assert.deepStrictEqual(value, ui32[key]);
   }
 }
 
-{
-  // copy c into b, without specifying sourceEnd
-  b.fill(++cntr);
-  c.fill(++cntr);
-  var copied = c.copy(b, 0, 0);
-//   console.log('copied %d bytes from c into b w/o sourceEnd', copied);
-  assert.strictEqual(c.length, copied);
-  for (var i = 0; i < c.length; i++) {
-    assert.strictEqual(c[i], b[i]);
-  }
-}
-
-{
-  // copy c into b, without specifying sourceStart
-  b.fill(++cntr);
-  c.fill(++cntr);
-  var copied = c.copy(b, 0);
-//   console.log('copied %d bytes from c into b w/o sourceStart', copied);
-  assert.strictEqual(c.length, copied);
-  for (var i = 0; i < c.length; i++) {
-    assert.strictEqual(c[i], b[i]);
-  }
-}
-
-{
-  // copy longer buffer b to shorter c without targetStart
-  b.fill(++cntr);
-  c.fill(++cntr);
-  var copied = b.copy(c);
-//   console.log('copied %d bytes from b into c w/o targetStart', copied);
-  assert.strictEqual(c.length, copied);
-  for (var i = 0; i < c.length; i++) {
-    assert.strictEqual(b[i], c[i]);
-  }
-}
-
-{
-  // copy starting near end of b to c
-  b.fill(++cntr);
-  c.fill(++cntr);
-  var copied = b.copy(c, 0, b.length - Math.floor(c.length / 2));
-//   console.log('copied %d bytes from end of b into beginning of c', copied);
-  assert.strictEqual(Math.floor(c.length / 2), copied);
-  for (var i = 0; i < Math.floor(c.length / 2); i++) {
-    assert.strictEqual(b[b.length - Math.floor(c.length / 2) + i], c[i]);
-  }
-  for (var i = Math.floor(c.length / 2) + 1; i < c.length; i++) {
-    assert.strictEqual(c[c.length - 1], c[i]);
-  }
-}
-
-{
-  // try to copy 513 bytes, and check we don't overrun c
-  b.fill(++cntr);
-  c.fill(++cntr);
-  var copied = b.copy(c, 0, 0, 513);
-//   console.log('copied %d bytes from b trying to overrun c', copied);
-  assert.strictEqual(c.length, copied);
-  for (var i = 0; i < c.length; i++) {
-    assert.strictEqual(b[i], c[i]);
-  }
-}
-
-{
-  // copy 768 bytes from b into b
-  b.fill(++cntr);
-  b.fill(++cntr, 256);
-  var copied = b.copy(b, 0, 256, 1024);
-//   console.log('copied %d bytes from b into b', copied);
-  assert.strictEqual(768, copied);
-  for (var i = 0; i < b.length; i++) {
-    assert.strictEqual(cntr, b[i]);
-  }
-}
-
-// copy string longer than buffer length (failure will segfault)
-var bb = Buffer.allocUnsafe(10);
-bb.fill('hello crazy world');
-
-
-// try to copy from before the beginning of b
-assert.doesNotThrow(() => { b.copy(c, 0, 100, 10); });
-
-// copy throws at negative sourceStart
-assert.throws(function() {
-  Buffer.allocUnsafe(5).copy(Buffer.allocUnsafe(5), 0, -1);
-}, RangeError);
-
-{
-  // check sourceEnd resets to targetEnd if former is greater than the latter
-  b.fill(++cntr);
-  c.fill(++cntr);
-  var copied = b.copy(c, 0, 0, 1025);
-//   console.log('copied %d bytes from b into c', copied);
-  for (var i = 0; i < c.length; i++) {
-    assert.strictEqual(b[i], c[i]);
-  }
-}
-
-// throw with negative sourceEnd
-// console.log('test copy at negative sourceEnd');
-assert.throws(function() {
-  b.copy(c, 0, 0, -1);
-}, RangeError);
-
-// when sourceStart is greater than sourceEnd, zero copied
-assert.equal(b.copy(c, 0, 100, 10), 0);
-
-// when targetStart > targetLength, zero copied
-assert.equal(b.copy(c, 512, 0, 10), 0);
-
-var caught_error;
-
-// invalid encoding for Buffer.toString
-caught_error = null;
-try {
-  b.toString('invalid');
-} catch (err) {
-  caught_error = err;
-}
-assert.strictEqual('Unknown encoding: invalid', caught_error.message);
-
+// Test invalid encoding for Buffer.toString
+assert.throws(() => b.toString('invalid'),
+              /Unknown encoding: invalid/);
 // invalid encoding for Buffer.write
-caught_error = null;
-try {
-  b.write('test string', 0, 5, 'invalid');
-} catch (err) {
-  caught_error = err;
-}
-assert.strictEqual('Unknown encoding: invalid', caught_error.message);
+assert.throws(() => b.write('test string', 0, 5, 'invalid'),
+              /Unknown encoding: invalid/);
+// unsupported arguments for Buffer.write
+assert.throws(() => b.write('test', 'utf8', 0),
+              /is no longer supported/);
+
 
 // try to create 0-length buffers
-Buffer.from('');
-Buffer.from('', 'ascii');
-Buffer.from('', 'latin1');
-Buffer.alloc(0);
-Buffer.allocUnsafe(0);
+assert.doesNotThrow(() => Buffer.from(''));
+assert.doesNotThrow(() => Buffer.from('', 'ascii'));
+assert.doesNotThrow(() => Buffer.from('', 'latin1'));
+assert.doesNotThrow(() => Buffer.alloc(0));
+assert.doesNotThrow(() => Buffer.allocUnsafe(0));
+assert.doesNotThrow(() => new Buffer(''));
+assert.doesNotThrow(() => new Buffer('', 'ascii'));
+assert.doesNotThrow(() => new Buffer('', 'latin1'));
+assert.doesNotThrow(() => new Buffer('', 'binary'));
+assert.doesNotThrow(() => Buffer(0));
 
 // try to write a 0-length string beyond the end of b
-assert.throws(function() {
-  b.write('', 2048);
-}, RangeError);
+assert.throws(() => b.write('', 2048), RangeError);
 
 // throw when writing to negative offset
-assert.throws(function() {
-  b.write('a', -1);
-}, RangeError);
+assert.throws(() => b.write('a', -1), RangeError);
 
 // throw when writing past bounds from the pool
-assert.throws(function() {
-  b.write('a', 2048);
-}, RangeError);
+assert.throws(() => b.write('a', 2048), RangeError);
 
 // throw when writing to negative offset
-assert.throws(function() {
-  b.write('a', -1);
-}, RangeError);
+assert.throws(() => b.write('a', -1), RangeError);
 
 // try to copy 0 bytes worth of data into an empty buffer
 b.copy(Buffer.alloc(0), 0, 0, 0);
@@ -271,94 +97,20 @@ b.copy(Buffer.alloc(1), 1, 1, 1);
 // try to copy 0 bytes from past the end of the source buffer
 b.copy(Buffer.alloc(1), 0, 2048, 2048);
 
-var rangeBuffer = Buffer.from('abc');
-
-// if start >= buffer's length, empty string will be returned
-assert.equal(rangeBuffer.toString('ascii', 3), '');
-assert.equal(rangeBuffer.toString('ascii', +Infinity), '');
-assert.equal(rangeBuffer.toString('ascii', 3.14, 3), '');
-assert.equal(rangeBuffer.toString('ascii', 'Infinity', 3), '');
-
-// if end <= 0, empty string will be returned
-assert.equal(rangeBuffer.toString('ascii', 1, 0), '');
-assert.equal(rangeBuffer.toString('ascii', 1, -1.2), '');
-assert.equal(rangeBuffer.toString('ascii', 1, -100), '');
-assert.equal(rangeBuffer.toString('ascii', 1, -Infinity), '');
-
-// if start < 0, start will be taken as zero
-assert.equal(rangeBuffer.toString('ascii', -1, 3), 'abc');
-assert.equal(rangeBuffer.toString('ascii', -1.99, 3), 'abc');
-assert.equal(rangeBuffer.toString('ascii', -Infinity, 3), 'abc');
-assert.equal(rangeBuffer.toString('ascii', '-1', 3), 'abc');
-assert.equal(rangeBuffer.toString('ascii', '-1.99', 3), 'abc');
-assert.equal(rangeBuffer.toString('ascii', '-Infinity', 3), 'abc');
-
-// if start is an invalid integer, start will be taken as zero
-assert.equal(rangeBuffer.toString('ascii', 'node.js', 3), 'abc');
-assert.equal(rangeBuffer.toString('ascii', {}, 3), 'abc');
-assert.equal(rangeBuffer.toString('ascii', [], 3), 'abc');
-assert.equal(rangeBuffer.toString('ascii', NaN, 3), 'abc');
-assert.equal(rangeBuffer.toString('ascii', null, 3), 'abc');
-assert.equal(rangeBuffer.toString('ascii', undefined, 3), 'abc');
-assert.equal(rangeBuffer.toString('ascii', false, 3), 'abc');
-assert.equal(rangeBuffer.toString('ascii', '', 3), 'abc');
-
-// but, if start is an integer when coerced, then it will be coerced and used.
-assert.equal(rangeBuffer.toString('ascii', '-1', 3), 'abc');
-assert.equal(rangeBuffer.toString('ascii', '1', 3), 'bc');
-assert.equal(rangeBuffer.toString('ascii', '-Infinity', 3), 'abc');
-assert.equal(rangeBuffer.toString('ascii', '3', 3), '');
-assert.equal(rangeBuffer.toString('ascii', Number(3), 3), '');
-assert.equal(rangeBuffer.toString('ascii', '3.14', 3), '');
-assert.equal(rangeBuffer.toString('ascii', '1.99', 3), 'bc');
-assert.equal(rangeBuffer.toString('ascii', '-1.99', 3), 'abc');
-assert.equal(rangeBuffer.toString('ascii', 1.99, 3), 'bc');
-assert.equal(rangeBuffer.toString('ascii', true, 3), 'bc');
-
-// if end > buffer's length, end will be taken as buffer's length
-assert.equal(rangeBuffer.toString('ascii', 0, 5), 'abc');
-assert.equal(rangeBuffer.toString('ascii', 0, 6.99), 'abc');
-assert.equal(rangeBuffer.toString('ascii', 0, Infinity), 'abc');
-assert.equal(rangeBuffer.toString('ascii', 0, '5'), 'abc');
-assert.equal(rangeBuffer.toString('ascii', 0, '6.99'), 'abc');
-assert.equal(rangeBuffer.toString('ascii', 0, 'Infinity'), 'abc');
-
-// if end is an invalid integer, end will be taken as buffer's length
-assert.equal(rangeBuffer.toString('ascii', 0, 'node.js'), '');
-assert.equal(rangeBuffer.toString('ascii', 0, {}), '');
-assert.equal(rangeBuffer.toString('ascii', 0, NaN), '');
-assert.equal(rangeBuffer.toString('ascii', 0, undefined), 'abc');
-assert.equal(rangeBuffer.toString('ascii', 0), 'abc');
-assert.equal(rangeBuffer.toString('ascii', 0, null), '');
-assert.equal(rangeBuffer.toString('ascii', 0, []), '');
-assert.equal(rangeBuffer.toString('ascii', 0, false), '');
-assert.equal(rangeBuffer.toString('ascii', 0, ''), '');
-
-// but, if end is an integer when coerced, then it will be coerced and used.
-assert.equal(rangeBuffer.toString('ascii', 0, '-1'), '');
-assert.equal(rangeBuffer.toString('ascii', 0, '1'), 'a');
-assert.equal(rangeBuffer.toString('ascii', 0, '-Infinity'), '');
-assert.equal(rangeBuffer.toString('ascii', 0, '3'), 'abc');
-assert.equal(rangeBuffer.toString('ascii', 0, Number(3)), 'abc');
-assert.equal(rangeBuffer.toString('ascii', 0, '3.14'), 'abc');
-assert.equal(rangeBuffer.toString('ascii', 0, '1.99'), 'a');
-assert.equal(rangeBuffer.toString('ascii', 0, '-1.99'), '');
-assert.equal(rangeBuffer.toString('ascii', 0, 1.99), 'a');
-assert.equal(rangeBuffer.toString('ascii', 0, true), 'a');
-
-// try toString() with a object as a encoding
-assert.equal(rangeBuffer.toString({toString: function() {
-  return 'ascii';
-}}), 'abc');
-
 // testing for smart defaults and ability to pass string values as offset
-var writeTest = Buffer.from('abcdes');
-writeTest.write('n', 'ascii');
-writeTest.write('o', '1', 'ascii');
-writeTest.write('d', '2', 'ascii');
-writeTest.write('e', 3, 'ascii');
-writeTest.write('j', 4, 'ascii');
-assert.equal(writeTest.toString(), 'nodejs');
+{
+  var writeTest = Buffer.from('abcdes');
+  writeTest.write('n', 'ascii');
+  writeTest.write('o', '1', 'ascii');
+  writeTest.write('d', '2', 'ascii');
+  writeTest.write('e', 3, 'ascii');
+  writeTest.write('j', 4, 'ascii');
+  assert.strictEqual(writeTest.toString(), 'nodejs');
+}
+
+// Offset points to the end of the buffer
+// (see https://github.com/nodejs/node/issues/8127).
+assert.doesNotThrow(() => Buffer.alloc(1).write('', 1, 0));
 
 // ASCII slice test
 {
@@ -368,17 +120,16 @@ assert.equal(writeTest.toString(), 'nodejs');
     b[i] = asciiString.charCodeAt(i);
   }
   var asciiSlice = b.toString('ascii', 0, asciiString.length);
-  assert.equal(asciiString, asciiSlice);
+  assert.strictEqual(asciiString, asciiSlice);
 }
 
 {
   var asciiString = 'hello world';
   var offset = 100;
 
-  var written = b.write(asciiString, offset, 'ascii');
-  assert.equal(asciiString.length, written);
+  assert.strictEqual(asciiString.length, b.write(asciiString, offset, 'ascii'));
   var asciiSlice = b.toString('ascii', offset, offset + asciiString.length);
-  assert.equal(asciiString, asciiSlice);
+  assert.strictEqual(asciiString, asciiSlice);
 }
 
 {
@@ -388,45 +139,47 @@ assert.equal(writeTest.toString(), 'nodejs');
   var sliceA = b.slice(offset, offset + asciiString.length);
   var sliceB = b.slice(offset, offset + asciiString.length);
   for (var i = 0; i < asciiString.length; i++) {
-    assert.equal(sliceA[i], sliceB[i]);
+    assert.strictEqual(sliceA[i], sliceB[i]);
   }
 }
 
 // UTF-8 slice test
-
-var utf8String = '¡hέlló wôrld!';
-var offset = 100;
-
-b.write(utf8String, 0, Buffer.byteLength(utf8String), 'utf8');
-var utf8Slice = b.toString('utf8', 0, Buffer.byteLength(utf8String));
-assert.equal(utf8String, utf8Slice);
-
-var written = b.write(utf8String, offset, 'utf8');
-assert.equal(Buffer.byteLength(utf8String), written);
-utf8Slice = b.toString('utf8', offset, offset + Buffer.byteLength(utf8String));
-assert.equal(utf8String, utf8Slice);
-
-var sliceA = b.slice(offset, offset + Buffer.byteLength(utf8String));
-var sliceB = b.slice(offset, offset + Buffer.byteLength(utf8String));
-for (var i = 0; i < Buffer.byteLength(utf8String); i++) {
-  assert.equal(sliceA[i], sliceB[i]);
-}
-
 {
-  var slice = b.slice(100, 150);
-  assert.equal(50, slice.length);
-  for (var i = 0; i < 50; i++) {
-    assert.equal(b[100 + i], slice[i]);
+  var utf8String = '¡hέlló wôrld!';
+  var offset = 100;
+
+  b.write(utf8String, 0, Buffer.byteLength(utf8String), 'utf8');
+  var utf8Slice = b.toString('utf8', 0, Buffer.byteLength(utf8String));
+  assert.strictEqual(utf8String, utf8Slice);
+
+  assert.strictEqual(Buffer.byteLength(utf8String),
+                     b.write(utf8String, offset, 'utf8'));
+  utf8Slice = b.toString('utf8', offset,
+                         offset + Buffer.byteLength(utf8String));
+  assert.strictEqual(utf8String, utf8Slice);
+
+  var sliceA = b.slice(offset, offset + Buffer.byteLength(utf8String));
+  var sliceB = b.slice(offset, offset + Buffer.byteLength(utf8String));
+  for (var i = 0; i < Buffer.byteLength(utf8String); i++) {
+    assert.strictEqual(sliceA[i], sliceB[i]);
   }
 }
-
+/*
+{
+  var slice = b.slice(100, 150);
+  assert.strictEqual(50, slice.length);
+  for (var i = 0; i < 50; i++) {
+    assert.strictEqual(b[100 + i], slice[i]);
+  }
+}
+*/
 {
   // make sure only top level parent propagates from allocPool
   var b = Buffer.allocUnsafe(5);
   var c = b.slice(0, 4);
   var d = c.slice(0, 2);
-  assert.equal(b.parent, c.parent);
-  assert.equal(b.parent, d.parent);
+  assert.strictEqual(b.parent, c.parent);
+  assert.strictEqual(b.parent, d.parent);
 }
 
 {
@@ -434,7 +187,7 @@ for (var i = 0; i < Buffer.byteLength(utf8String); i++) {
   var b = Buffer.allocUnsafeSlow(5);
   var c = b.slice(0, 4);
   var d = c.slice(0, 2);
-  assert.equal(c.parent, d.parent);
+  assert.strictEqual(c.parent, d.parent);
 }
 
 {
@@ -442,9 +195,8 @@ for (var i = 0; i < Buffer.byteLength(utf8String); i++) {
   var testValue = '\u00F6\u65E5\u672C\u8A9E'; // ö日本語
   var buffer = Buffer.allocUnsafe(32);
   var size = buffer.write(testValue, 0, 'utf8');
-//   console.log('bytes written to buffer: ' + size);
   var slice = buffer.toString('utf8', 0, size);
-  assert.equal(slice, testValue);
+  assert.strictEqual(slice, testValue);
 }
 
 {
@@ -452,80 +204,81 @@ for (var i = 0; i < Buffer.byteLength(utf8String); i++) {
   var a = Buffer.allocUnsafe(8);
   for (var i = 0; i < 8; i++) a[i] = i;
   var b = a.slice(4, 8);
-  assert.equal(4, b[0]);
-  assert.equal(5, b[1]);
-  assert.equal(6, b[2]);
-  assert.equal(7, b[3]);
+  assert.strictEqual(4, b[0]);
+  assert.strictEqual(5, b[1]);
+  assert.strictEqual(6, b[2]);
+  assert.strictEqual(7, b[3]);
   var c = b.slice(2, 4);
-  assert.equal(6, c[0]);
-  assert.equal(7, c[1]);
+  assert.strictEqual(6, c[0]);
+  assert.strictEqual(7, c[1]);
 }
 
 {
   var d = Buffer.from([23, 42, 255]);
-  assert.equal(d.length, 3);
-  assert.equal(d[0], 23);
-  assert.equal(d[1], 42);
-  assert.equal(d[2], 255);
+  assert.strictEqual(d.length, 3);
+  assert.strictEqual(d[0], 23);
+  assert.strictEqual(d[1], 42);
+  assert.strictEqual(d[2], 255);
   assert.deepStrictEqual(d, Buffer.from(d));
 }
 
 {
+  // Test for proper UTF-8 Encoding
   var e = Buffer.from('über');
-//   console.error('uber: \'%s\'', e.toString());
   assert.deepStrictEqual(e, Buffer.from([195, 188, 98, 101, 114]));
 }
 
 {
+  // Test for proper ascii Encoding, length should be 4
   var f = Buffer.from('über', 'ascii');
-//   console.error('f.length: %d     (should be 4)', f.length);
   assert.deepStrictEqual(f, Buffer.from([252, 98, 101, 114]));
 }
 
-['ucs2', 'ucs-2', 'utf16le', 'utf-16le'].forEach(function(encoding) {
+['ucs2', 'ucs-2', 'utf16le', 'utf-16le'].forEach((encoding) => {
   {
+    // Test for proper UTF16LE encoding, length should be 8
     var f = Buffer.from('über', encoding);
-//     console.error('f.length: %d     (should be 8)', f.length);
     assert.deepStrictEqual(f, Buffer.from([252, 0, 98, 0, 101, 0, 114, 0]));
   }
 
   {
+    // Length should be 12
     var f = Buffer.from('привет', encoding);
-//     console.error('f.length: %d     (should be 12)', f.length);
-    assert.deepStrictEqual(f,
-      Buffer.from([63, 4, 64, 4, 56, 4, 50, 4, 53, 4, 66, 4]));
-    assert.equal(f.toString(encoding), 'привет');
+    assert.deepStrictEqual(
+      f, Buffer.from([63, 4, 64, 4, 56, 4, 50, 4, 53, 4, 66, 4])
+    );
+    assert.strictEqual(f.toString(encoding), 'привет');
   }
 
   {
     var f = Buffer.from([0, 0, 0, 0, 0]);
-    assert.equal(f.length, 5);
+    assert.strictEqual(f.length, 5);
     var size = f.write('あいうえお', encoding);
-//     console.error('bytes written to buffer: %d     (should be 4)', size);
-    assert.equal(size, 4);
+    assert.strictEqual(size, 4);
     assert.deepStrictEqual(f, Buffer.from([0x42, 0x30, 0x44, 0x30, 0x00]));
   }
 });
 
 {
   var f = Buffer.from('\uD83D\uDC4D', 'utf-16le'); // THUMBS UP SIGN (U+1F44D)
-  assert.equal(f.length, 4);
+  assert.strictEqual(f.length, 4);
   assert.deepStrictEqual(f, Buffer.from('3DD84DDC', 'hex'));
 }
 
-
-var arrayIsh = {0: 0, 1: 1, 2: 2, 3: 3, length: 4};
-var g = Buffer.from(arrayIsh);
-assert.deepStrictEqual(g, Buffer.from([0, 1, 2, 3]));
-var strArrayIsh = {0: '0', 1: '1', 2: '2', 3: '3', length: 4};
-g = Buffer.from(strArrayIsh);
-assert.deepStrictEqual(g, Buffer.from([0, 1, 2, 3]));
-
+// Test construction from arrayish object
+{
+  var arrayIsh = { 0: 0, 1: 1, 2: 2, 3: 3, length: 4 };
+  var g = Buffer.from(arrayIsh);
+  assert.deepStrictEqual(g, Buffer.from([0, 1, 2, 3]));
+  var strArrayIsh = { 0: '0', 1: '1', 2: '2', 3: '3', length: 4 };
+  g = Buffer.from(strArrayIsh);
+  assert.deepStrictEqual(g, Buffer.from([0, 1, 2, 3]));
+}
 
 //
 // Test toString('base64')
 //
-assert.equal('TWFu', (Buffer.from('Man')).toString('base64'));
+assert.strictEqual('TWFu', (Buffer.from('Man')).toString('base64'));
 
 {
   // test that regular and URL-safe base64 both work
@@ -550,30 +303,30 @@ assert.equal('TWFu', (Buffer.from('Man')).toString('base64'));
                    'dWVkIGFuZCBpbmRlZmF0aWdhYmxlIGdlbmVyYXRpb24gb2Yga25vd2xlZ' +
                    'GdlLCBleGNlZWRzIHRoZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm' +
                    '5hbCBwbGVhc3VyZS4=';
-  assert.equal(expected, (Buffer.from(quote)).toString('base64'));
+  assert.strictEqual(expected, (Buffer.from(quote)).toString('base64'));
 
   var b = Buffer.allocUnsafe(1024);
   var bytesWritten = b.write(expected, 0, 'base64');
-  assert.equal(quote.length, bytesWritten);
-  assert.equal(quote, b.toString('ascii', 0, quote.length));
+  assert.strictEqual(quote.length, bytesWritten);
+  assert.strictEqual(quote, b.toString('ascii', 0, quote.length));
 
   // check that the base64 decoder ignores whitespace
-  var expectedWhite = expected.slice(0, 60) + ' \n' +
-                        expected.slice(60, 120) + ' \n' +
-                        expected.slice(120, 180) + ' \n' +
-                        expected.slice(180, 240) + ' \n' +
-                        expected.slice(240, 300) + '\n' +
-                        expected.slice(300, 360) + '\n';
+  var expectedWhite = `${expected.slice(0, 60)} \n` +
+                        `${expected.slice(60, 120)} \n` +
+                        `${expected.slice(120, 180)} \n` +
+                        `${expected.slice(180, 240)} \n` +
+                        `${expected.slice(240, 300)}\n` +
+                        `${expected.slice(300, 360)}\n`;
   b = Buffer.allocUnsafe(1024);
   bytesWritten = b.write(expectedWhite, 0, 'base64');
-  assert.equal(quote.length, bytesWritten);
-  assert.equal(quote, b.toString('ascii', 0, quote.length));
+  assert.strictEqual(quote.length, bytesWritten);
+  assert.strictEqual(quote, b.toString('ascii', 0, quote.length));
 
   // check that the base64 decoder on the constructor works
   // even in the presence of whitespace.
   b = Buffer.from(expectedWhite, 'base64');
-  assert.equal(quote.length, b.length);
-  assert.equal(quote, b.toString('ascii', 0, quote.length));
+  assert.strictEqual(quote.length, b.length);
+  assert.strictEqual(quote, b.toString('ascii', 0, quote.length));
 
   // check that the base64 decoder ignores illegal chars
   var expectedIllegal = expected.slice(0, 60) + ' \x80' +
@@ -583,102 +336,114 @@ assert.equal('TWFu', (Buffer.from('Man')).toString('base64'));
                           expected.slice(240, 300) + '\x03' +
                           expected.slice(300, 360);
   b = Buffer.from(expectedIllegal, 'base64');
-  assert.equal(quote.length, b.length);
-  assert.equal(quote, b.toString('ascii', 0, quote.length));
+  assert.strictEqual(quote.length, b.length);
+  assert.strictEqual(quote, b.toString('ascii', 0, quote.length));
 }
 
-assert.equal(Buffer.from('', 'base64').toString(), '');
-assert.equal(Buffer.from('K', 'base64').toString(), '');
+assert.strictEqual(Buffer.from('', 'base64').toString(), '');
+assert.strictEqual(Buffer.from('K', 'base64').toString(), '');
 
 // multiple-of-4 with padding
-assert.equal(Buffer.from('Kg==', 'base64').toString(), '*');
-assert.equal(Buffer.from('Kio=', 'base64').toString(), '**');
-assert.equal(Buffer.from('Kioq', 'base64').toString(), '***');
-assert.equal(Buffer.from('KioqKg==', 'base64').toString(), '****');
-assert.equal(Buffer.from('KioqKio=', 'base64').toString(), '*****');
-assert.equal(Buffer.from('KioqKioq', 'base64').toString(), '******');
-assert.equal(Buffer.from('KioqKioqKg==', 'base64').toString(), '*******');
-assert.equal(Buffer.from('KioqKioqKio=', 'base64').toString(), '********');
-assert.equal(Buffer.from('KioqKioqKioq', 'base64').toString(), '*********');
-assert.equal(Buffer.from('KioqKioqKioqKg==', 'base64').toString(),
-             '**********');
-assert.equal(Buffer.from('KioqKioqKioqKio=', 'base64').toString(),
-             '***********');
-assert.equal(Buffer.from('KioqKioqKioqKioq', 'base64').toString(),
-             '************');
-assert.equal(Buffer.from('KioqKioqKioqKioqKg==', 'base64').toString(),
-             '*************');
-assert.equal(Buffer.from('KioqKioqKioqKioqKio=', 'base64').toString(),
-             '**************');
-assert.equal(Buffer.from('KioqKioqKioqKioqKioq', 'base64').toString(),
-             '***************');
-assert.equal(Buffer.from('KioqKioqKioqKioqKioqKg==', 'base64').toString(),
-             '****************');
-assert.equal(Buffer.from('KioqKioqKioqKioqKioqKio=', 'base64').toString(),
-             '*****************');
-assert.equal(Buffer.from('KioqKioqKioqKioqKioqKioq', 'base64').toString(),
-             '******************');
-assert.equal(Buffer.from('KioqKioqKioqKioqKioqKioqKg==', 'base64').toString(),
-             '*******************');
-assert.equal(Buffer.from('KioqKioqKioqKioqKioqKioqKio=', 'base64').toString(),
-             '********************');
+assert.strictEqual(Buffer.from('Kg==', 'base64').toString(), '*');
+assert.strictEqual(Buffer.from('Kio=', 'base64').toString(), '*'.repeat(2));
+assert.strictEqual(Buffer.from('Kioq', 'base64').toString(), '*'.repeat(3));
+assert.strictEqual(Buffer.from('KioqKg==', 'base64').toString(), '*'.repeat(4));
+assert.strictEqual(Buffer.from('KioqKio=', 'base64').toString(), '*'.repeat(5));
+assert.strictEqual(Buffer.from('KioqKioq', 'base64').toString(), '*'.repeat(6));
+assert.strictEqual(Buffer.from('KioqKioqKg==', 'base64').toString(),
+                   '*'.repeat(7));
+assert.strictEqual(Buffer.from('KioqKioqKio=', 'base64').toString(),
+                   '*'.repeat(8));
+assert.strictEqual(Buffer.from('KioqKioqKioq', 'base64').toString(),
+                   '*'.repeat(9));
+assert.strictEqual(Buffer.from('KioqKioqKioqKg==', 'base64').toString(),
+                   '*'.repeat(10));
+assert.strictEqual(Buffer.from('KioqKioqKioqKio=', 'base64').toString(),
+                   '*'.repeat(11));
+assert.strictEqual(Buffer.from('KioqKioqKioqKioq', 'base64').toString(),
+                   '*'.repeat(12));
+assert.strictEqual(Buffer.from('KioqKioqKioqKioqKg==', 'base64').toString(),
+                   '*'.repeat(13));
+assert.strictEqual(Buffer.from('KioqKioqKioqKioqKio=', 'base64').toString(),
+                   '*'.repeat(14));
+assert.strictEqual(Buffer.from('KioqKioqKioqKioqKioq', 'base64').toString(),
+                   '*'.repeat(15));
+assert.strictEqual(Buffer.from('KioqKioqKioqKioqKioqKg==', 'base64').toString(),
+                   '*'.repeat(16));
+assert.strictEqual(Buffer.from('KioqKioqKioqKioqKioqKio=', 'base64').toString(),
+                   '*'.repeat(17));
+assert.strictEqual(Buffer.from('KioqKioqKioqKioqKioqKioq', 'base64').toString(),
+                   '*'.repeat(18));
+assert.strictEqual(Buffer.from('KioqKioqKioqKioqKioqKioqKg==',
+                               'base64').toString(),
+                   '*'.repeat(19));
+assert.strictEqual(Buffer.from('KioqKioqKioqKioqKioqKioqKio=',
+                               'base64').toString(),
+                   '*'.repeat(20));
 
 // no padding, not a multiple of 4
-assert.equal(Buffer.from('Kg', 'base64').toString(), '*');
-assert.equal(Buffer.from('Kio', 'base64').toString(), '**');
-assert.equal(Buffer.from('KioqKg', 'base64').toString(), '****');
-assert.equal(Buffer.from('KioqKio', 'base64').toString(), '*****');
-assert.equal(Buffer.from('KioqKioqKg', 'base64').toString(), '*******');
-assert.equal(Buffer.from('KioqKioqKio', 'base64').toString(), '********');
-assert.equal(Buffer.from('KioqKioqKioqKg', 'base64').toString(), '**********');
-assert.equal(Buffer.from('KioqKioqKioqKio', 'base64').toString(),
-             '***********');
-assert.equal(Buffer.from('KioqKioqKioqKioqKg', 'base64').toString(),
-             '*************');
-assert.equal(Buffer.from('KioqKioqKioqKioqKio', 'base64').toString(),
-             '**************');
-assert.equal(Buffer.from('KioqKioqKioqKioqKioqKg', 'base64').toString(),
-             '****************');
-assert.equal(Buffer.from('KioqKioqKioqKioqKioqKio', 'base64').toString(),
-             '*****************');
-assert.equal(Buffer.from('KioqKioqKioqKioqKioqKioqKg', 'base64').toString(),
-             '*******************');
-assert.equal(Buffer.from('KioqKioqKioqKioqKioqKioqKio', 'base64').toString(),
-             '********************');
+assert.strictEqual(Buffer.from('Kg', 'base64').toString(), '*');
+assert.strictEqual(Buffer.from('Kio', 'base64').toString(), '*'.repeat(2));
+assert.strictEqual(Buffer.from('KioqKg', 'base64').toString(), '*'.repeat(4));
+assert.strictEqual(Buffer.from('KioqKio', 'base64').toString(), '*'.repeat(5));
+assert.strictEqual(Buffer.from('KioqKioqKg', 'base64').toString(),
+                   '*'.repeat(7));
+assert.strictEqual(Buffer.from('KioqKioqKio', 'base64').toString(),
+                   '*'.repeat(8));
+assert.strictEqual(Buffer.from('KioqKioqKioqKg', 'base64').toString(),
+                   '*'.repeat(10));
+assert.strictEqual(Buffer.from('KioqKioqKioqKio', 'base64').toString(),
+                   '*'.repeat(11));
+assert.strictEqual(Buffer.from('KioqKioqKioqKioqKg', 'base64').toString(),
+                   '*'.repeat(13));
+assert.strictEqual(Buffer.from('KioqKioqKioqKioqKio', 'base64').toString(),
+                   '*'.repeat(14));
+assert.strictEqual(Buffer.from('KioqKioqKioqKioqKioqKg', 'base64').toString(),
+                   '*'.repeat(16));
+assert.strictEqual(Buffer.from('KioqKioqKioqKioqKioqKio', 'base64').toString(),
+                   '*'.repeat(17));
+assert.strictEqual(Buffer.from('KioqKioqKioqKioqKioqKioqKg',
+                               'base64').toString(),
+                   '*'.repeat(19));
+assert.strictEqual(Buffer.from('KioqKioqKioqKioqKioqKioqKio',
+                               'base64').toString(),
+                   '*'.repeat(20));
 
 // handle padding graciously, multiple-of-4 or not
-assert.equal(
+assert.strictEqual(
   Buffer.from('72INjkR5fchcxk9+VgdGPFJDxUBFR5/rMFsghgxADiw==', 'base64').length,
   32
 );
-assert.equal(
+assert.strictEqual(
   Buffer.from('72INjkR5fchcxk9+VgdGPFJDxUBFR5/rMFsghgxADiw=', 'base64').length,
   32
 );
-assert.equal(
+assert.strictEqual(
   Buffer.from('72INjkR5fchcxk9+VgdGPFJDxUBFR5/rMFsghgxADiw', 'base64').length,
   32
 );
-assert.equal(
+assert.strictEqual(
   Buffer.from('w69jACy6BgZmaFvv96HG6MYksWytuZu3T1FvGnulPg==', 'base64').length,
   31
 );
-assert.equal(
+assert.strictEqual(
   Buffer.from('w69jACy6BgZmaFvv96HG6MYksWytuZu3T1FvGnulPg=', 'base64').length,
   31
 );
-assert.equal(
+assert.strictEqual(
   Buffer.from('w69jACy6BgZmaFvv96HG6MYksWytuZu3T1FvGnulPg', 'base64').length,
   31
 );
 
+{
 // This string encodes single '.' character in UTF-16
-var dot = Buffer.from('//4uAA==', 'base64');
-assert.equal(dot[0], 0xff);
-assert.equal(dot[1], 0xfe);
-assert.equal(dot[2], 0x2e);
-assert.equal(dot[3], 0x00);
-assert.equal(dot.toString('base64'), '//4uAA==');
+  var dot = Buffer.from('//4uAA==', 'base64');
+  assert.strictEqual(dot[0], 0xff);
+  assert.strictEqual(dot[1], 0xfe);
+  assert.strictEqual(dot[2], 0x2e);
+  assert.strictEqual(dot[3], 0x00);
+  assert.strictEqual(dot.toString('base64'), '//4uAA==');
+}
 
 {
   // Writing base64 at a position > 0 should not mangle the result.
@@ -691,88 +456,91 @@ assert.equal(dot.toString('base64'), '//4uAA==');
   for (var i = 0; i < segments.length; ++i) {
     pos += b.write(segments[i], pos, 'base64');
   }
-  assert.equal(b.toString('latin1', 0, pos), 'Madness?! This is node.js!');
+  assert.strictEqual(b.toString('latin1', 0, pos),
+                     'Madness?! This is node.js!');
 }
-
+/*
 // Regression test for https://github.com/nodejs/node/issues/3496.
-// assert.equal(Buffer.from('=bad'.repeat(1e4), 'base64').length, 0);
+assert.strictEqual(Buffer.from('=bad'.repeat(1e4), 'base64').length, 0);
+*/
+// Regression test for https://github.com/nodejs/node/issues/11987.
+assert.deepStrictEqual(Buffer.from('w0  ', 'base64'),
+                       Buffer.from('w0', 'base64'));
+
+// Regression test for https://github.com/nodejs/node/issues/13657.
+assert.deepStrictEqual(Buffer.from(' YWJvcnVtLg', 'base64'),
+                       Buffer.from('YWJvcnVtLg', 'base64'));
 
 {
   // Creating buffers larger than pool size.
   var l = Buffer.poolSize + 5;
-  var s = '';
-  for (var i = 0; i < l; i++) {
-    s += 'h';
-  }
-
+  var s = 'h'.repeat(l);
   var b = Buffer.from(s);
 
   for (var i = 0; i < l; i++) {
-    assert.equal('h'.charCodeAt(0), b[i]);
+    assert.strictEqual('h'.charCodeAt(0), b[i]);
   }
 
   var sb = b.toString();
-  assert.equal(sb.length, s.length);
-  assert.equal(sb, s);
+  assert.strictEqual(sb.length, s.length);
+  assert.strictEqual(sb, s);
 }
 
 {
-  // Single argument slice
-  var b = Buffer.from('abcde');
-  assert.equal('bcde', b.slice(1).toString());
-}
+  // test hex toString
+  var hexb = Buffer.allocUnsafe(256);
+  for (var i = 0; i < 256; i++) {
+    hexb[i] = i;
+  }
+  var hexStr = hexb.toString('hex');
+  assert.strictEqual(hexStr,
+                     '000102030405060708090a0b0c0d0e0f' +
+                     '101112131415161718191a1b1c1d1e1f' +
+                     '202122232425262728292a2b2c2d2e2f' +
+                     '303132333435363738393a3b3c3d3e3f' +
+                     '404142434445464748494a4b4c4d4e4f' +
+                     '505152535455565758595a5b5c5d5e5f' +
+                     '606162636465666768696a6b6c6d6e6f' +
+                     '707172737475767778797a7b7c7d7e7f' +
+                     '808182838485868788898a8b8c8d8e8f' +
+                     '909192939495969798999a9b9c9d9e9f' +
+                     'a0a1a2a3a4a5a6a7a8a9aaabacadaeaf' +
+                     'b0b1b2b3b4b5b6b7b8b9babbbcbdbebf' +
+                     'c0c1c2c3c4c5c6c7c8c9cacbcccdcecf' +
+                     'd0d1d2d3d4d5d6d7d8d9dadbdcdddedf' +
+                     'e0e1e2e3e4e5e6e7e8e9eaebecedeeef' +
+                     'f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff');
 
-// slice(0,0).length === 0
-assert.equal(0, Buffer.from('hello').slice(0, 0).length);
-
-// test hex toString
-// console.log('Create hex string from buffer');
-var hexb = Buffer.allocUnsafe(256);
-for (var i = 0; i < 256; i++) {
-  hexb[i] = i;
+  var hexb2 = Buffer.from(hexStr, 'hex');
+  for (var i = 0; i < 256; i++) {
+    assert.strictEqual(hexb2[i], hexb[i]);
+  }
 }
-var hexStr = hexb.toString('hex');
-assert.equal(hexStr,
-             '000102030405060708090a0b0c0d0e0f' +
-             '101112131415161718191a1b1c1d1e1f' +
-             '202122232425262728292a2b2c2d2e2f' +
-             '303132333435363738393a3b3c3d3e3f' +
-             '404142434445464748494a4b4c4d4e4f' +
-             '505152535455565758595a5b5c5d5e5f' +
-             '606162636465666768696a6b6c6d6e6f' +
-             '707172737475767778797a7b7c7d7e7f' +
-             '808182838485868788898a8b8c8d8e8f' +
-             '909192939495969798999a9b9c9d9e9f' +
-             'a0a1a2a3a4a5a6a7a8a9aaabacadaeaf' +
-             'b0b1b2b3b4b5b6b7b8b9babbbcbdbebf' +
-             'c0c1c2c3c4c5c6c7c8c9cacbcccdcecf' +
-             'd0d1d2d3d4d5d6d7d8d9dadbdcdddedf' +
-             'e0e1e2e3e4e5e6e7e8e9eaebecedeeef' +
-             'f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff');
+/*
+// Test single hex character is discarded.
+assert.strictEqual(Buffer.from('A', 'hex').length, 0);
 
-// console.log('Create buffer from hex string');
-var hexb2 = Buffer.from(hexStr, 'hex');
-for (var i = 0; i < 256; i++) {
-  assert.equal(hexb2[i], hexb[i]);
-}
+// Test that if a trailing character is discarded, rest of string is processed.
+assert.deepStrictEqual(Buffer.from('Abx', 'hex'), Buffer.from('Ab', 'hex'));
+*/
+// Test single base64 char encodes as 0.
+assert.strictEqual(Buffer.from('A', 'base64').length, 0);
+
 
 {
   // test an invalid slice end.
-//   console.log('Try to slice off the end of the buffer');
   var b = Buffer.from([1, 2, 3, 4, 5]);
   var b2 = b.toString('hex', 1, 10000);
   var b3 = b.toString('hex', 1, 5);
   var b4 = b.toString('hex', 1);
-  assert.equal(b2, b3);
-  assert.equal(b2, b4);
+  assert.strictEqual(b2, b3);
+  assert.strictEqual(b2, b4);
 }
 
 function buildBuffer(data) {
   if (Array.isArray(data)) {
     var buffer = Buffer.allocUnsafe(data.length);
-    data.forEach(function(v, k) {
-      buffer[k] = v;
-    });
+    data.forEach((v, k) => buffer[k] = v);
     return buffer;
   }
   return null;
@@ -780,177 +548,169 @@ function buildBuffer(data) {
 
 var x = buildBuffer([0x81, 0xa3, 0x66, 0x6f, 0x6f, 0xa3, 0x62, 0x61, 0x72]);
 
-// console.log(x.inspect());
-assert.equal('<Buffer 81 a3 66 6f 6f a3 62 61 72>', x.inspect());
+assert.strictEqual('<Buffer 81 a3 66 6f 6f a3 62 61 72>', x.inspect());
 
 {
   var z = x.slice(4);
-//   console.log(z.inspect());
-//   console.log(z.length);
-  assert.equal(5, z.length);
-  assert.equal(0x6f, z[0]);
-  assert.equal(0xa3, z[1]);
-  assert.equal(0x62, z[2]);
-  assert.equal(0x61, z[3]);
-  assert.equal(0x72, z[4]);
+  assert.strictEqual(5, z.length);
+  assert.strictEqual(0x6f, z[0]);
+  assert.strictEqual(0xa3, z[1]);
+  assert.strictEqual(0x62, z[2]);
+  assert.strictEqual(0x61, z[3]);
+  assert.strictEqual(0x72, z[4]);
 }
 
 {
   var z = x.slice(0);
-//   console.log(z.inspect());
-//   console.log(z.length);
-  assert.equal(z.length, x.length);
+  assert.strictEqual(z.length, x.length);
 }
 
 {
   var z = x.slice(0, 4);
-//   console.log(z.inspect());
-//   console.log(z.length);
-  assert.equal(4, z.length);
-  assert.equal(0x81, z[0]);
-  assert.equal(0xa3, z[1]);
+  assert.strictEqual(4, z.length);
+  assert.strictEqual(0x81, z[0]);
+  assert.strictEqual(0xa3, z[1]);
 }
 
 {
   var z = x.slice(0, 9);
-//   console.log(z.inspect());
-//   console.log(z.length);
-  assert.equal(9, z.length);
+  assert.strictEqual(9, z.length);
 }
 
 {
   var z = x.slice(1, 4);
-//   console.log(z.inspect());
-//   console.log(z.length);
-  assert.equal(3, z.length);
-  assert.equal(0xa3, z[0]);
+  assert.strictEqual(3, z.length);
+  assert.strictEqual(0xa3, z[0]);
 }
 
 {
   var z = x.slice(2, 4);
-//   console.log(z.inspect());
-//   console.log(z.length);
-  assert.equal(2, z.length);
-  assert.equal(0x66, z[0]);
-  assert.equal(0x6f, z[1]);
+  assert.strictEqual(2, z.length);
+  assert.strictEqual(0x66, z[0]);
+  assert.strictEqual(0x6f, z[1]);
 }
 
-assert.equal(0, Buffer.from('hello').slice(0, 0).length);
-
-['ucs2', 'ucs-2', 'utf16le', 'utf-16le'].forEach(function(encoding) {
+['ucs2', 'ucs-2', 'utf16le', 'utf-16le'].forEach((encoding) => {
   var b = Buffer.allocUnsafe(10);
   b.write('あいうえお', encoding);
-  assert.equal(b.toString(encoding), 'あいうえお');
+  assert.strictEqual(b.toString(encoding), 'あいうえお');
 });
+
+['ucs2', 'ucs-2', 'utf16le', 'utf-16le'].forEach((encoding) => {
+  var b = Buffer.allocUnsafe(11);
+  b.write('あいうえお', 1, encoding);
+  assert.strictEqual(b.toString(encoding, 1), 'あいうえお');
+});
+
+{
+  // latin1 encoding should write only one byte per character.
+  var b = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
+  var s = String.fromCharCode(0xffff);
+  b.write(s, 0, 'latin1');
+  assert.strictEqual(0xff, b[0]);
+  assert.strictEqual(0xad, b[1]);
+  assert.strictEqual(0xbe, b[2]);
+  assert.strictEqual(0xef, b[3]);
+  s = String.fromCharCode(0xaaee);
+  b.write(s, 0, 'latin1');
+  assert.strictEqual(0xee, b[0]);
+  assert.strictEqual(0xad, b[1]);
+  assert.strictEqual(0xbe, b[2]);
+  assert.strictEqual(0xef, b[3]);
+}
 
 {
   // Binary encoding should write only one byte per character.
   var b = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
   var s = String.fromCharCode(0xffff);
   b.write(s, 0, 'latin1');
-  assert.equal(0xff, b[0]);
-  assert.equal(0xad, b[1]);
-  assert.equal(0xbe, b[2]);
-  assert.equal(0xef, b[3]);
+  assert.strictEqual(0xff, b[0]);
+  assert.strictEqual(0xad, b[1]);
+  assert.strictEqual(0xbe, b[2]);
+  assert.strictEqual(0xef, b[3]);
   s = String.fromCharCode(0xaaee);
   b.write(s, 0, 'latin1');
-  assert.equal(0xee, b[0]);
-  assert.equal(0xad, b[1]);
-  assert.equal(0xbe, b[2]);
-  assert.equal(0xef, b[3]);
+  assert.strictEqual(0xee, b[0]);
+  assert.strictEqual(0xad, b[1]);
+  assert.strictEqual(0xbe, b[2]);
+  assert.strictEqual(0xef, b[3]);
 }
 
 {
-  // #1210 Test UTF-8 string includes null character
+  // https://github.com/nodejs/node-v0.x-archive/pull/1210
+  // Test UTF-8 string includes null character
   var buf = Buffer.from('\0');
-  assert.equal(buf.length, 1);
+  assert.strictEqual(buf.length, 1);
   buf = Buffer.from('\0\0');
-  assert.equal(buf.length, 2);
+  assert.strictEqual(buf.length, 2);
 }
 
 {
   var buf = Buffer.allocUnsafe(2);
-  var written = buf.write(''); // 0byte
-  assert.equal(written, 0);
-  written = buf.write('\0'); // 1byte (v8 adds null terminator)
-  assert.equal(written, 1);
-  written = buf.write('a\0'); // 1byte * 2
-  assert.equal(written, 2);
-  written = buf.write('あ'); // 3bytes
-  assert.equal(written, 0);
-  written = buf.write('\0あ'); // 1byte + 3bytes
-  assert.equal(written, 1);
-  written = buf.write('\0\0あ'); // 1byte * 2 + 3bytes
-  assert.equal(written, 2);
+  assert.strictEqual(buf.write(''), 0); //0bytes
+  assert.strictEqual(buf.write('\0'), 1); // 1byte (v8 adds null terminator)
+  assert.strictEqual(buf.write('a\0'), 2); // 1byte * 2
+  assert.strictEqual(buf.write('あ'), 0); // 3bytes
+  assert.strictEqual(buf.write('\0あ'), 1); // 1byte + 3bytes
+  assert.strictEqual(buf.write('\0\0あ'), 2); // 1byte * 2 + 3bytes
 }
 
 {
   var buf = Buffer.allocUnsafe(10);
-  written = buf.write('あいう'); // 3bytes * 3 (v8 adds null terminator)
-  assert.equal(written, 9);
-  written = buf.write('あいう\0'); // 3bytes * 3 + 1byte
-  assert.equal(written, 10);
+  assert.strictEqual(buf.write('あいう'), 9); // 3bytes * 3 (v8 adds null term.)
+  assert.strictEqual(buf.write('あいう\0'), 10); // 3bytes * 3 + 1byte
 }
 
 {
-  // #243 Test write() with maxLength
+  // https://github.com/nodejs/node-v0.x-archive/issues/243
+  // Test write() with maxLength
   var buf = Buffer.allocUnsafe(4);
   buf.fill(0xFF);
-  var written = buf.write('abcd', 1, 2, 'utf8');
-//   console.log(buf);
-  assert.equal(written, 2);
-  assert.equal(buf[0], 0xFF);
-  assert.equal(buf[1], 0x61);
-  assert.equal(buf[2], 0x62);
-  assert.equal(buf[3], 0xFF);
+  assert.strictEqual(buf.write('abcd', 1, 2, 'utf8'), 2);
+  assert.strictEqual(buf[0], 0xFF);
+  assert.strictEqual(buf[1], 0x61);
+  assert.strictEqual(buf[2], 0x62);
+  assert.strictEqual(buf[3], 0xFF);
 
   buf.fill(0xFF);
-  written = buf.write('abcd', 1, 4);
-//   console.log(buf);
-  assert.equal(written, 3);
-  assert.equal(buf[0], 0xFF);
-  assert.equal(buf[1], 0x61);
-  assert.equal(buf[2], 0x62);
-  assert.equal(buf[3], 0x63);
+  assert.strictEqual(buf.write('abcd', 1, 4), 3);
+  assert.strictEqual(buf[0], 0xFF);
+  assert.strictEqual(buf[1], 0x61);
+  assert.strictEqual(buf[2], 0x62);
+  assert.strictEqual(buf[3], 0x63);
 
   buf.fill(0xFF);
-  written = buf.write('abcd', 1, 2, 'utf8');
-//   console.log(buf);
-  assert.equal(written, 2);
-  assert.equal(buf[0], 0xFF);
-  assert.equal(buf[1], 0x61);
-  assert.equal(buf[2], 0x62);
-  assert.equal(buf[3], 0xFF);
+  assert.strictEqual(buf.write('abcd', 1, 2, 'utf8'), 2);
+  assert.strictEqual(buf[0], 0xFF);
+  assert.strictEqual(buf[1], 0x61);
+  assert.strictEqual(buf[2], 0x62);
+  assert.strictEqual(buf[3], 0xFF);
 
   buf.fill(0xFF);
-  written = buf.write('abcdef', 1, 2, 'hex');
-//   console.log(buf);
-  assert.equal(written, 2);
-  assert.equal(buf[0], 0xFF);
-  assert.equal(buf[1], 0xAB);
-  assert.equal(buf[2], 0xCD);
-  assert.equal(buf[3], 0xFF);
+  assert.strictEqual(buf.write('abcdef', 1, 2, 'hex'), 2);
+  assert.strictEqual(buf[0], 0xFF);
+  assert.strictEqual(buf[1], 0xAB);
+  assert.strictEqual(buf[2], 0xCD);
+  assert.strictEqual(buf[3], 0xFF);
 
-  ['ucs2', 'ucs-2', 'utf16le', 'utf-16le'].forEach(function(encoding) {
+  ['ucs2', 'ucs-2', 'utf16le', 'utf-16le'].forEach((encoding) => {
     buf.fill(0xFF);
-    written = buf.write('abcd', 0, 2, encoding);
-//     console.log(buf);
-    assert.equal(written, 2);
-    assert.equal(buf[0], 0x61);
-    assert.equal(buf[1], 0x00);
-    assert.equal(buf[2], 0xFF);
-    assert.equal(buf[3], 0xFF);
+    assert.strictEqual(buf.write('abcd', 0, 2, encoding), 2);
+    assert.strictEqual(buf[0], 0x61);
+    assert.strictEqual(buf[1], 0x00);
+    assert.strictEqual(buf[2], 0xFF);
+    assert.strictEqual(buf[3], 0xFF);
   });
 }
 
 {
   // test offset returns are correct
   var b = Buffer.allocUnsafe(16);
-  assert.equal(4, b.writeUInt32LE(0, 0));
-  assert.equal(6, b.writeUInt16LE(0, 4));
-  assert.equal(7, b.writeUInt8(0, 6));
-  assert.equal(8, b.writeInt8(0, 7));
-  assert.equal(16, b.writeDoubleLE(0, 8));
+  assert.strictEqual(4, b.writeUInt32LE(0, 0));
+  assert.strictEqual(6, b.writeUInt16LE(0, 4));
+  assert.strictEqual(7, b.writeUInt8(0, 6));
+  assert.strictEqual(8, b.writeInt8(0, 7));
+  assert.strictEqual(16, b.writeDoubleLE(0, 8));
 }
 
 {
@@ -958,43 +718,55 @@ assert.equal(0, Buffer.from('hello').slice(0, 0).length);
   // ef bf bd = utf-8 representation of unicode replacement character
   // see https://codereview.chromium.org/121173009/
   var buf = Buffer.from('ab\ud800cd', 'utf8');
-  assert.equal(buf[0], 0x61);
-  assert.equal(buf[1], 0x62);
-  assert.equal(buf[2], 0xef);
-  assert.equal(buf[3], 0xbf);
-  assert.equal(buf[4], 0xbd);
-  assert.equal(buf[5], 0x63);
-  assert.equal(buf[6], 0x64);
+  assert.strictEqual(buf[0], 0x61);
+  assert.strictEqual(buf[1], 0x62);
+  assert.strictEqual(buf[2], 0xef);
+  assert.strictEqual(buf[3], 0xbf);
+  assert.strictEqual(buf[4], 0xbd);
+  assert.strictEqual(buf[5], 0x63);
+  assert.strictEqual(buf[6], 0x64);
 }
 
 {
   // test for buffer overrun
   var buf = Buffer.from([0, 0, 0, 0, 0]); // length: 5
   var sub = buf.slice(0, 4);         // length: 4
-  written = sub.write('12345', 'latin1');
-  assert.equal(written, 4);
-  assert.equal(buf[4], 0);
+  assert.strictEqual(sub.write('12345', 'latin1'), 4);
+  assert.strictEqual(buf[4], 0);
+  assert.strictEqual(sub.write('12345', 'binary'), 4);
+  assert.strictEqual(buf[4], 0);
 }
+
+{
+  // test alloc with fill option
+  var buf = Buffer.alloc(5, '800A', 'hex');
+  assert.strictEqual(buf[0], 128);
+  assert.strictEqual(buf[1], 10);
+  assert.strictEqual(buf[2], 128);
+  assert.strictEqual(buf[3], 10);
+  assert.strictEqual(buf[4], 128);
+}
+
 
 // Check for fractional length args, junk length args, etc.
 // https://github.com/joyent/node/issues/1758
 
 // Call .fill() first, stops valgrind warning about uninitialized memory reads.
 Buffer.allocUnsafe(3.3).fill().toString();
-  // throws bad argument error in commit 43cb4ec
+// throws bad argument error in commit 43cb4ec
 Buffer.alloc(3.3).fill().toString();
-assert.equal(Buffer.allocUnsafe(NaN).length, 0);
-assert.equal(Buffer.allocUnsafe(3.3).length, 3);
-assert.equal(Buffer.from({length: 3.3}).length, 3);
-assert.equal(Buffer.from({length: 'BAM'}).length, 0);
+assert.strictEqual(Buffer.allocUnsafe(NaN).length, 0);
+assert.strictEqual(Buffer.allocUnsafe(3.3).length, 3);
+assert.strictEqual(Buffer.from({ length: 3.3 }).length, 3);
+assert.strictEqual(Buffer.from({ length: 'BAM' }).length, 0);
 
 // Make sure that strings are not coerced to numbers.
-assert.equal(Buffer.from('99').length, 2);
-assert.equal(Buffer.from('13.37').length, 5);
+assert.strictEqual(Buffer.from('99').length, 2);
+assert.strictEqual(Buffer.from('13.37').length, 5);
 
 // Ensure that the length argument is respected.
-'ascii utf8 hex base64 latin1'.split(' ').forEach(function(enc) {
-  assert.equal(Buffer.allocUnsafe(1).write('aaaaaa', 0, 1, enc), 1);
+['ascii', 'utf8', 'hex', 'base64', 'latin1', 'binary'].forEach((enc) => {
+  assert.strictEqual(Buffer.allocUnsafe(1).write('aaaaaa', 0, 1, enc), 1);
 });
 
 {
@@ -1002,346 +774,137 @@ assert.equal(Buffer.from('13.37').length, 5);
   var a = Buffer.allocUnsafe(3);
   var b = Buffer.from('xxx');
   a.write('aaaaaaaa', 'base64');
-  assert.equal(b.toString(), 'xxx');
+  assert.strictEqual(b.toString(), 'xxx');
 }
 
 // issue GH-3416
 Buffer.from(Buffer.allocUnsafe(0), 0, 0);
 
-[ 'hex',
-  'utf8',
-  'utf-8',
-  'ascii',
-  'latin1',
-  'binary',
-  'base64',
-  'ucs2',
-  'ucs-2',
-  'utf16le',
-  'utf-16le' ].forEach(function(enc) {
-    assert.equal(Buffer.isEncoding(enc), true);
-  });
-
-[ 'utf9',
-  'utf-7',
-  'Unicode-FTW',
-  'new gnu gun',
-  false,
-  NaN,
-  {},
-  Infinity,
-  [],
-  1,
-  0,
-  -1 ].forEach(function(enc) {
-    assert.equal(Buffer.isEncoding(enc), false);
-  });
-
-
-// GH-5110
-{
-  var buffer = Buffer.from('test');
-  var string = JSON.stringify(buffer);
-
-  assert.strictEqual(string, '{"type":"Buffer","data":[116,101,115,116]}');
-
-  assert.deepStrictEqual(buffer, JSON.parse(string, function(key, value) {
-    return value && value.type === 'Buffer'
-      ? Buffer.from(value.data)
-      : value;
-  }));
-}
-
-// issue GH-7849
-{
-  var buf = Buffer.from('test');
-  var json = JSON.stringify(buf);
-  var obj = JSON.parse(json);
-  var copy = Buffer.from(obj);
-
-  assert(buf.equals(copy));
-}
-
-// issue GH-4331
-assert.throws(function() {
-  Buffer.allocUnsafe(0xFFFFFFFF);
-}, RangeError);
-assert.throws(function() {
-  Buffer.allocUnsafe(0xFFFFFFFFF);
-}, RangeError);
-
+// issue GH-5587
+assert.throws(() => Buffer.alloc(8).writeFloatLE(0, 5), RangeError);
+assert.throws(() => Buffer.alloc(16).writeDoubleLE(0, 9), RangeError);
 
 // attempt to overflow buffers, similar to previous bug in array buffers
-assert.throws(function() {
-  var buf = Buffer.allocUnsafe(8);
-  buf.readFloatLE(0xffffffff);
-}, RangeError);
-
-assert.throws(function() {
-  var buf = Buffer.allocUnsafe(8);
-  buf.writeFloatLE(0.0, 0xffffffff);
-}, RangeError);
-
-assert.throws(function() {
-  var buf = Buffer.allocUnsafe(8);
-  buf.readFloatLE(0xffffffff);
-}, RangeError);
-
-assert.throws(function() {
-  var buf = Buffer.allocUnsafe(8);
-  buf.writeFloatLE(0.0, 0xffffffff);
-}, RangeError);
+assert.throws(() => Buffer.allocUnsafe(8).writeFloatLE(0.0, 0xffffffff),
+              RangeError);
+assert.throws(() => Buffer.allocUnsafe(8).writeFloatLE(0.0, 0xffffffff),
+              RangeError);
 
 
 // ensure negative values can't get past offset
-assert.throws(function() {
-  var buf = Buffer.allocUnsafe(8);
-  buf.readFloatLE(-1);
-}, RangeError);
+assert.throws(() => Buffer.allocUnsafe(8).writeFloatLE(0.0, -1), RangeError);
+assert.throws(() => Buffer.allocUnsafe(8).writeFloatLE(0.0, -1), RangeError);
 
-assert.throws(function() {
-  var buf = Buffer.allocUnsafe(8);
-  buf.writeFloatLE(0.0, -1);
-}, RangeError);
-
-assert.throws(function() {
-  var buf = Buffer.allocUnsafe(8);
-  buf.readFloatLE(-1);
-}, RangeError);
-
-assert.throws(function() {
-  var buf = Buffer.allocUnsafe(8);
-  buf.writeFloatLE(0.0, -1);
-}, RangeError);
-
-// offset checks
-{
-  var buf = Buffer.allocUnsafe(0);
-
-  assert.throws(function() { buf.readUInt8(0); }, RangeError);
-  assert.throws(function() { buf.readInt8(0); }, RangeError);
-}
-
-{
-  var buf = Buffer.from([0xFF]);
-
-  assert.equal(buf.readUInt8(0), 255);
-  assert.equal(buf.readInt8(0), -1);
-}
-
-[16, 32].forEach(function(bits) {
-  var buf = Buffer.allocUnsafe(bits / 8 - 1);
-
-  assert.throws(function() { buf['readUInt' + bits + 'BE'](0); },
-                RangeError,
-                'readUInt' + bits + 'BE');
-
-  assert.throws(function() { buf['readUInt' + bits + 'LE'](0); },
-                RangeError,
-                'readUInt' + bits + 'LE');
-
-  assert.throws(function() { buf['readInt' + bits + 'BE'](0); },
-                RangeError,
-                'readInt' + bits + 'BE()');
-
-  assert.throws(function() { buf['readInt' + bits + 'LE'](0); },
-                RangeError,
-                'readInt' + bits + 'LE()');
-});
-
-[16, 32].forEach(function(bits) {
-  var buf = Buffer.from([0xFF, 0xFF, 0xFF, 0xFF]);
-
-  assert.equal(buf['readUInt' + bits + 'BE'](0),
-                (0xFFFFFFFF >>> (32 - bits)));
-
-  assert.equal(buf['readUInt' + bits + 'LE'](0),
-                (0xFFFFFFFF >>> (32 - bits)));
-
-  assert.equal(buf['readInt' + bits + 'BE'](0),
-                (0xFFFFFFFF >> (32 - bits)));
-
-  assert.equal(buf['readInt' + bits + 'LE'](0),
-                (0xFFFFFFFF >> (32 - bits)));
-});
-
-// test for common read(U)IntLE/BE
-{
-  var buf = Buffer.from([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
-
-  assert.strictEqual(buf.readUIntLE(0, 1), 0x01);
-  assert.strictEqual(buf.readUIntBE(0, 1), 0x01);
-  assert.strictEqual(buf.readUIntLE(0, 3), 0x030201);
-  assert.strictEqual(buf.readUIntBE(0, 3), 0x010203);
-  assert.strictEqual(buf.readUIntLE(0, 5), 0x0504030201);
-  assert.strictEqual(buf.readUIntBE(0, 5), 0x0102030405);
-  assert.strictEqual(buf.readUIntLE(0, 6), 0x060504030201);
-  assert.strictEqual(buf.readUIntBE(0, 6), 0x010203040506);
-  assert.strictEqual(buf.readIntLE(0, 1), 0x01);
-  assert.strictEqual(buf.readIntBE(0, 1), 0x01);
-  assert.strictEqual(buf.readIntLE(0, 3), 0x030201);
-  assert.strictEqual(buf.readIntBE(0, 3), 0x010203);
-  assert.strictEqual(buf.readIntLE(0, 5), 0x0504030201);
-  assert.strictEqual(buf.readIntBE(0, 5), 0x0102030405);
-  assert.strictEqual(buf.readIntLE(0, 6), 0x060504030201);
-  assert.strictEqual(buf.readIntBE(0, 6), 0x010203040506);
-}
 
 // test for common write(U)IntLE/BE
 {
   var buf = Buffer.allocUnsafe(3);
   buf.writeUIntLE(0x123456, 0, 3);
   assert.deepStrictEqual(buf.toJSON().data, [0x56, 0x34, 0x12]);
-  assert.equal(buf.readUIntLE(0, 3), 0x123456);
+  assert.strictEqual(buf.readUIntLE(0, 3), 0x123456);
 
-  buf = Buffer.allocUnsafe(3);
+  buf.fill(0xFF);
   buf.writeUIntBE(0x123456, 0, 3);
   assert.deepStrictEqual(buf.toJSON().data, [0x12, 0x34, 0x56]);
-  assert.equal(buf.readUIntBE(0, 3), 0x123456);
+  assert.strictEqual(buf.readUIntBE(0, 3), 0x123456);
 
-  buf = Buffer.allocUnsafe(3);
+  buf.fill(0xFF);
   buf.writeIntLE(0x123456, 0, 3);
   assert.deepStrictEqual(buf.toJSON().data, [0x56, 0x34, 0x12]);
-  assert.equal(buf.readIntLE(0, 3), 0x123456);
+  assert.strictEqual(buf.readIntLE(0, 3), 0x123456);
 
-  buf = Buffer.allocUnsafe(3);
+  buf.fill(0xFF);
   buf.writeIntBE(0x123456, 0, 3);
   assert.deepStrictEqual(buf.toJSON().data, [0x12, 0x34, 0x56]);
-  assert.equal(buf.readIntBE(0, 3), 0x123456);
+  assert.strictEqual(buf.readIntBE(0, 3), 0x123456);
 
-  buf = Buffer.allocUnsafe(3);
+  buf.fill(0xFF);
   buf.writeIntLE(-0x123456, 0, 3);
   assert.deepStrictEqual(buf.toJSON().data, [0xaa, 0xcb, 0xed]);
-  assert.equal(buf.readIntLE(0, 3), -0x123456);
+  assert.strictEqual(buf.readIntLE(0, 3), -0x123456);
 
-  buf = Buffer.allocUnsafe(3);
+  buf.fill(0xFF);
   buf.writeIntBE(-0x123456, 0, 3);
   assert.deepStrictEqual(buf.toJSON().data, [0xed, 0xcb, 0xaa]);
-  assert.equal(buf.readIntBE(0, 3), -0x123456);
+  assert.strictEqual(buf.readIntBE(0, 3), -0x123456);
 
-  buf = Buffer.allocUnsafe(3);
+  buf.fill(0xFF);
   buf.writeIntLE(-0x123400, 0, 3);
   assert.deepStrictEqual(buf.toJSON().data, [0x00, 0xcc, 0xed]);
-  assert.equal(buf.readIntLE(0, 3), -0x123400);
+  assert.strictEqual(buf.readIntLE(0, 3), -0x123400);
 
-  buf = Buffer.allocUnsafe(3);
+  buf.fill(0xFF);
   buf.writeIntBE(-0x123400, 0, 3);
   assert.deepStrictEqual(buf.toJSON().data, [0xed, 0xcc, 0x00]);
-  assert.equal(buf.readIntBE(0, 3), -0x123400);
+  assert.strictEqual(buf.readIntBE(0, 3), -0x123400);
 
-  buf = Buffer.allocUnsafe(3);
+  buf.fill(0xFF);
   buf.writeIntLE(-0x120000, 0, 3);
   assert.deepStrictEqual(buf.toJSON().data, [0x00, 0x00, 0xee]);
-  assert.equal(buf.readIntLE(0, 3), -0x120000);
+  assert.strictEqual(buf.readIntLE(0, 3), -0x120000);
 
-  buf = Buffer.allocUnsafe(3);
+  buf.fill(0xFF);
   buf.writeIntBE(-0x120000, 0, 3);
   assert.deepStrictEqual(buf.toJSON().data, [0xee, 0x00, 0x00]);
-  assert.equal(buf.readIntBE(0, 3), -0x120000);
+  assert.strictEqual(buf.readIntBE(0, 3), -0x120000);
 
   buf = Buffer.allocUnsafe(5);
   buf.writeUIntLE(0x1234567890, 0, 5);
   assert.deepStrictEqual(buf.toJSON().data, [0x90, 0x78, 0x56, 0x34, 0x12]);
-  assert.equal(buf.readUIntLE(0, 5), 0x1234567890);
+  assert.strictEqual(buf.readUIntLE(0, 5), 0x1234567890);
 
-  buf = Buffer.allocUnsafe(5);
+  buf.fill(0xFF);
   buf.writeUIntBE(0x1234567890, 0, 5);
   assert.deepStrictEqual(buf.toJSON().data, [0x12, 0x34, 0x56, 0x78, 0x90]);
-  assert.equal(buf.readUIntBE(0, 5), 0x1234567890);
+  assert.strictEqual(buf.readUIntBE(0, 5), 0x1234567890);
 
-  buf = Buffer.allocUnsafe(5);
+  buf.fill(0xFF);
   buf.writeIntLE(0x1234567890, 0, 5);
   assert.deepStrictEqual(buf.toJSON().data, [0x90, 0x78, 0x56, 0x34, 0x12]);
-  assert.equal(buf.readIntLE(0, 5), 0x1234567890);
+  assert.strictEqual(buf.readIntLE(0, 5), 0x1234567890);
 
-  buf = Buffer.allocUnsafe(5);
+  buf.fill(0xFF);
   buf.writeIntBE(0x1234567890, 0, 5);
   assert.deepStrictEqual(buf.toJSON().data, [0x12, 0x34, 0x56, 0x78, 0x90]);
-  assert.equal(buf.readIntBE(0, 5), 0x1234567890);
+  assert.strictEqual(buf.readIntBE(0, 5), 0x1234567890);
 
-  buf = Buffer.allocUnsafe(5);
+  buf.fill(0xFF);
   buf.writeIntLE(-0x1234567890, 0, 5);
   assert.deepStrictEqual(buf.toJSON().data, [0x70, 0x87, 0xa9, 0xcb, 0xed]);
-  assert.equal(buf.readIntLE(0, 5), -0x1234567890);
+  assert.strictEqual(buf.readIntLE(0, 5), -0x1234567890);
 
-  buf = Buffer.allocUnsafe(5);
+  buf.fill(0xFF);
   buf.writeIntBE(-0x1234567890, 0, 5);
   assert.deepStrictEqual(buf.toJSON().data, [0xed, 0xcb, 0xa9, 0x87, 0x70]);
-  assert.equal(buf.readIntBE(0, 5), -0x1234567890);
+  assert.strictEqual(buf.readIntBE(0, 5), -0x1234567890);
 
-  buf = Buffer.allocUnsafe(5);
+  buf.fill(0xFF);
   buf.writeIntLE(-0x0012000000, 0, 5);
   assert.deepStrictEqual(buf.toJSON().data, [0x00, 0x00, 0x00, 0xee, 0xff]);
-  assert.equal(buf.readIntLE(0, 5), -0x0012000000);
+  assert.strictEqual(buf.readIntLE(0, 5), -0x0012000000);
 
-  buf = Buffer.allocUnsafe(5);
+  buf.fill(0xFF);
   buf.writeIntBE(-0x0012000000, 0, 5);
   assert.deepStrictEqual(buf.toJSON().data, [0xff, 0xee, 0x00, 0x00, 0x00]);
-  assert.equal(buf.readIntBE(0, 5), -0x0012000000);
+  assert.strictEqual(buf.readIntBE(0, 5), -0x0012000000);
 }
-
-// test Buffer slice
-{
-  var buf = Buffer.from('0123456789');
-  assert.equal(buf.slice(-10, 10), '0123456789');
-  assert.equal(buf.slice(-20, 10), '0123456789');
-  assert.equal(buf.slice(-20, -10), '');
-  assert.equal(buf.slice(), '0123456789');
-  assert.equal(buf.slice(0), '0123456789');
-  assert.equal(buf.slice(0, 0), '');
-  assert.equal(buf.slice(undefined), '0123456789');
-  assert.equal(buf.slice('foobar'), '0123456789');
-  assert.equal(buf.slice(undefined, undefined), '0123456789');
-
-  assert.equal(buf.slice(2), '23456789');
-  assert.equal(buf.slice(5), '56789');
-  assert.equal(buf.slice(10), '');
-  assert.equal(buf.slice(5, 8), '567');
-  assert.equal(buf.slice(8, -1), '8');
-  assert.equal(buf.slice(-10), '0123456789');
-  assert.equal(buf.slice(0, -9), '0');
-  assert.equal(buf.slice(0, -10), '');
-  assert.equal(buf.slice(0, -1), '012345678');
-  assert.equal(buf.slice(2, -2), '234567');
-  assert.equal(buf.slice(0, 65536), '0123456789');
-  assert.equal(buf.slice(65536, 0), '');
-  assert.equal(buf.slice(-5, -8), '');
-  assert.equal(buf.slice(-5, -3), '56');
-  assert.equal(buf.slice(-10, 10), '0123456789');
-  for (var i = 0, s = buf.toString(); i < buf.length; ++i) {
-    assert.equal(buf.slice(i), s.slice(i));
-    assert.equal(buf.slice(0, i), s.slice(0, i));
-    assert.equal(buf.slice(-i), s.slice(-i));
-    assert.equal(buf.slice(0, -i), s.slice(0, -i));
+/*
+// Regression test for https://github.com/nodejs/node-v0.x-archive/issues/5482:
+// should throw but not assert in C++ land.
+common.expectsError(
+  () => Buffer.from('', 'buffer'),
+  {
+    code: 'ERR_UNKNOWN_ENCODING',
+    type: TypeError,
+    message: 'Unknown encoding: buffer'
   }
-
-  var utf16Buf = Buffer.from('0123456789', 'utf16le');
-  // assert.deepStrictEqual(utf16Buf.slice(0, 6), Buffer.from('012', 'utf16le'));
-
-  assert.equal(buf.slice('0', '1'), '0');
-  assert.equal(buf.slice('-5', '10'), '56789');
-  assert.equal(buf.slice('-10', '10'), '0123456789');
-  assert.equal(buf.slice('-10', '-5'), '01234');
-  assert.equal(buf.slice('-10', '-0'), '');
-  assert.equal(buf.slice('111'), '');
-  assert.equal(buf.slice('0', '-111'), '');
-
-  // try to slice a zero length Buffer
-  // see https://github.com/joyent/node/issues/5881
-  Buffer.alloc(0).slice(0, 1);
-}
-
-// Regression test for #5482: should throw but not assert in C++ land.
-assert.throws(function() {
-  Buffer.from('', 'buffer');
-}, TypeError);
-
-// Regression test for #6111. Constructing a buffer from another buffer
-// should a) work, and b) not corrupt the source buffer.
+);
+*/
+// Regression test for https://github.com/nodejs/node-v0.x-archive/issues/6111.
+// Constructing a buffer from another buffer should a) work, and b) not corrupt
+// the source buffer.
 {
-  var a = [0];
-  for (var i = 0; i < 7; ++i) a = a.concat(a);
-  a = a.map(function(_, i) { return i; });
+  var a = [...Array(128).keys()]; // [0, 1, 2, 3, ... 126, 127]
   var b = Buffer.from(a);
   var c = Buffer.from(b);
   assert.strictEqual(b.length, a.length);
@@ -1352,150 +915,122 @@ assert.throws(function() {
     assert.strictEqual(c[i], i);
   }
 }
-
-
-assert.throws(function() {
-  Buffer.allocUnsafe((-1 >>> 0) + 1);
-}, RangeError);
-
-assert.throws(function() {
-  Buffer.allocUnsafeSlow((-1 >>> 0) + 1);
-}, RangeError);
-
-if (common.hasCrypto) {
+/*
+if (common.hasCrypto) { // eslint-disable-line crypto-check
   // Test truncation after decode
   var crypto = require('crypto');
 
   var b1 = Buffer.from('YW55=======', 'base64');
   var b2 = Buffer.from('YW55', 'base64');
 
-  assert.equal(
+  assert.strictEqual(
     crypto.createHash('sha1').update(b1).digest('hex'),
     crypto.createHash('sha1').update(b2).digest('hex')
   );
 } else {
-  common.skip('missing crypto');
+  common.printSkipMessage('missing crypto');
 }
-
-// Test Compare
-{
-  var b = Buffer.alloc(1, 'a');
-  var c = Buffer.alloc(1, 'c');
-  var d = Buffer.alloc(2, 'aa');
-
-  assert.equal(b.compare(c), -1);
-  assert.equal(c.compare(d), 1);
-  assert.equal(d.compare(b), 1);
-  assert.equal(b.compare(d), -1);
-  assert.equal(b.compare(b), 0);
-
-  assert.equal(Buffer.compare(b, c), -1);
-  assert.equal(Buffer.compare(c, d), 1);
-  assert.equal(Buffer.compare(d, b), 1);
-  assert.equal(Buffer.compare(b, d), -1);
-  assert.equal(Buffer.compare(c, c), 0);
-
-  assert.equal(Buffer.compare(Buffer.alloc(0), Buffer.alloc(0)), 0);
-  assert.equal(Buffer.compare(Buffer.alloc(0), Buffer.alloc(1)), -1);
-  assert.equal(Buffer.compare(Buffer.alloc(1), Buffer.alloc(0)), 1);
-}
-
-assert.throws(function() {
-  var b = Buffer.allocUnsafe(1);
-  Buffer.compare(b, 'abc');
-});
-
-assert.throws(function() {
-  var b = Buffer.allocUnsafe(1);
-  Buffer.compare('abc', b);
-});
-
-assert.throws(function() {
-  var b = Buffer.allocUnsafe(1);
-  b.compare('abc');
-});
-
-// Test Equals
-{
-  var b = Buffer.alloc(5, 'abcdf');
-  var c = Buffer.alloc(5, 'abcdf');
-  var d = Buffer.alloc(5, 'abcde');
-  var e = Buffer.alloc(6, 'abcdef');
-
-  assert.ok(b.equals(c));
-  assert.ok(!c.equals(d));
-  assert.ok(!d.equals(e));
-  assert.ok(d.equals(d));
-}
-
-assert.throws(function() {
-  var b = Buffer.allocUnsafe(1);
-  b.equals('abc');
-});
-
-// Regression test for https://github.com/nodejs/node/issues/649.
-assert.throws(() => { Buffer.allocUnsafe(1422561062959).toString('utf8');});
 
 var ps = Buffer.poolSize;
 Buffer.poolSize = 0;
-assert.equal(Buffer.allocUnsafe(1).parent, undefined);
+assert(Buffer.allocUnsafe(1).parent instanceof ArrayBuffer);
 Buffer.poolSize = ps;
 
 // Test Buffer.copy() segfault
-assert.throws(function() {
-  Buffer.allocUnsafe(10).copy();
-});
+assert.throws(() => Buffer.allocUnsafe(10).copy(),
+              /TypeError: argument should be a Buffer/);
 
-var regErrorMsg = new RegExp('First argument must be a string, Buffer, ' +
-                               'ArrayBuffer, Array, or array-like object.');
+var regErrorMsg =
+  new RegExp('The first argument must be one of type string, Buffer, ' +
+             'ArrayBuffer, Array, or Array-like Object\\.');
 
-assert.throws(function() {
-  Buffer.from();
-}, regErrorMsg);
+assert.throws(() => Buffer.from(), regErrorMsg);
+assert.throws(() => Buffer.from(null), regErrorMsg);
+*/
+// Test prototype getters don't throw
+assert.strictEqual(Buffer.prototype.parent, undefined);
+assert.strictEqual(Buffer.prototype.offset, undefined);
+assert.strictEqual(SlowBuffer.prototype.parent, undefined);
+assert.strictEqual(SlowBuffer.prototype.offset, undefined);
 
-assert.throws(function() {
-  Buffer.from(null);
-}, regErrorMsg);
 
+{
+  // Test that large negative Buffer length inputs don't affect the pool offset.
+  // Use the fromArrayLike() variant here because it's more lenient
+  // about its input and passes the length directly to allocate().
+  assert.deepStrictEqual(Buffer.from({ length: -Buffer.poolSize }),
+                         Buffer.from(''));
+  assert.deepStrictEqual(Buffer.from({ length: -100 }),
+                         Buffer.from(''));
 
+  // Check pool offset after that by trying to write string into the pool.
+  assert.doesNotThrow(() => Buffer.from('abc'));
+}
+
+/*
 // Test that ParseArrayIndex handles full uint32
-assert.throws(function() {
-  Buffer.from(new ArrayBuffer(0), -1 >>> 0);
-}, /RangeError: 'offset' is out of bounds/);
+{
+  var errMsg = common.expectsError({
+    code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+    type: RangeError,
+    message: '"offset" is outside of buffer bounds'
+  });
+  assert.throws(() => Buffer.from(new ArrayBuffer(0), -1 >>> 0), errMsg);
+}
 
 // ParseArrayIndex() should reject values that don't fit in a 32 bits size_t.
-assert.throws(() => {
-  var a = Buffer(1).fill(0);
-  var b = Buffer(1).fill(0);
+common.expectsError(() => {
+  var a = Buffer.alloc(1);
+  var b = Buffer.alloc(1);
   a.copy(b, 0, 0x100000000, 0x100000001);
-}), /out of range index/;
-
+}, { code: undefined, type: RangeError, message: 'Index out of range' });
+*/
 // Unpooled buffer (replaces SlowBuffer)
-var ubuf = Buffer.allocUnsafeSlow(10);
-assert(ubuf);
-assert(ubuf.buffer);
-assert.equal(ubuf.buffer.byteLength, 10);
+{
+  var ubuf = Buffer.allocUnsafeSlow(10);
+  assert(ubuf);
+  assert(ubuf.buffer);
+  assert.strictEqual(ubuf.buffer.byteLength, 10);
+}
 
 // Regression test
-assert.doesNotThrow(() => {
-  Buffer.from(new ArrayBuffer());
-});
+assert.doesNotThrow(() => Buffer.from(new ArrayBuffer()));
 
-assert.throws(() => Buffer.alloc(-Buffer.poolSize),
-              '"size" argument must not be negative');
-assert.throws(() => Buffer.alloc(-100),
-              '"size" argument must not be negative');
-assert.throws(() => Buffer.allocUnsafe(-Buffer.poolSize),
-              '"size" argument must not be negative');
-assert.throws(() => Buffer.allocUnsafe(-100),
-              '"size" argument must not be negative');
-assert.throws(() => Buffer.allocUnsafeSlow(-Buffer.poolSize),
-              '"size" argument must not be negative');
-assert.throws(() => Buffer.allocUnsafeSlow(-100),
-              '"size" argument must not be negative');
+// Test that ArrayBuffer from a different context is detected correctly
+var arrayBuf = vm.runInNewContext('new ArrayBuffer()');
+assert.doesNotThrow(() => Buffer.from(arrayBuf));
+/*
+assert.doesNotThrow(() => Buffer.from({ buffer: arrayBuf }));
 
 assert.throws(() => Buffer.alloc({ valueOf: () => 1 }),
-              /"size" argument must be a number/);
+              /"size" argument must be of type number/);
 assert.throws(() => Buffer.alloc({ valueOf: () => -1 }),
-              /"size" argument must be a number/);
+              /"size" argument must be of type number/);
 
+assert.strictEqual(Buffer.prototype.toLocaleString, Buffer.prototype.toString);
+{
+  var buf = Buffer.from('test');
+  assert.strictEqual(buf.toLocaleString(), buf.toString());
+}
+
+common.expectsError(() => {
+  Buffer.alloc(0x1000, 'This is not correctly encoded', 'hex');
+}, {
+  code: 'ERR_INVALID_ARG_VALUE',
+  type: TypeError
+});
+
+common.expectsError(() => {
+  Buffer.alloc(0x1000, 'c', 'hex');
+}, {
+  code: 'ERR_INVALID_ARG_VALUE',
+  type: TypeError
+});
+
+common.expectsError(() => {
+  Buffer.alloc(1, Buffer.alloc(0));
+}, {
+  code: 'ERR_INVALID_ARG_VALUE',
+  type: TypeError
+});
+*/

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -939,14 +939,14 @@ Buffer.poolSize = ps;
 // Test Buffer.copy() segfault
 assert.throws(() => Buffer.allocUnsafe(10).copy(),
               /TypeError: argument should be a Buffer/);
-/*
+
 var regErrorMsg =
   new RegExp('The first argument must be one of type string, Buffer, ' +
              'ArrayBuffer, Array, or Array-like Object\\.');
 
 assert.throws(() => Buffer.from(), regErrorMsg);
 assert.throws(() => Buffer.from(null), regErrorMsg);
-*/
+
 // Test prototype getters don't throw
 assert.strictEqual(Buffer.prototype.parent, undefined);
 assert.strictEqual(Buffer.prototype.offset, undefined);

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -1018,14 +1018,14 @@ common.expectsError(() => {
   code: 'ERR_INVALID_ARG_VALUE',
   type: TypeError
 });
-/*
+
 common.expectsError(() => {
   Buffer.alloc(0x1000, 'c', 'hex');
 }, {
   code: 'ERR_INVALID_ARG_VALUE',
   type: TypeError
 });
-*/
+
 common.expectsError(() => {
   Buffer.alloc(1, Buffer.alloc(0));
 }, {

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -32,7 +32,7 @@ assert.strictEqual(0, d.length);
   var b = Buffer.alloc(128);
   assert.strictEqual(128, b.length);
   assert.strictEqual(0, b.byteOffset);
-  //assert.strictEqual(0, b.offset);
+  assert.strictEqual(0, b.offset);
 }
 
 // Test creating a Buffer from a Uint32Array

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -931,12 +931,12 @@ if (common.hasCrypto) { // eslint-disable-line crypto-check
 } else {
   common.printSkipMessage('missing crypto');
 }
-/*
+
 var ps = Buffer.poolSize;
 Buffer.poolSize = 0;
 assert(Buffer.allocUnsafe(1).parent instanceof ArrayBuffer);
 Buffer.poolSize = ps;
-*/
+
 // Test Buffer.copy() segfault
 assert.throws(() => Buffer.allocUnsafe(10).copy(),
               /TypeError: argument should be a Buffer/);

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -1000,12 +1000,12 @@ assert.doesNotThrow(() => Buffer.from(new ArrayBuffer()));
 var arrayBuf = vm.runInNewContext('new ArrayBuffer()');
 assert.doesNotThrow(() => Buffer.from(arrayBuf));
 assert.doesNotThrow(() => Buffer.from({ buffer: arrayBuf }));
-/*
+
 assert.throws(() => Buffer.alloc({ valueOf: () => 1 }),
               /"size" argument must be of type number/);
 assert.throws(() => Buffer.alloc({ valueOf: () => -1 }),
               /"size" argument must be of type number/);
-
+/*
 assert.strictEqual(Buffer.prototype.toLocaleString, Buffer.prototype.toString);
 {
   var buf = Buffer.from('test');

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-var common = { skip: function () {} };
+var common = require('../common.js');
 var assert = require('assert');
 var vm = require('vm');
 
@@ -888,7 +888,7 @@ assert.throws(() => Buffer.allocUnsafe(8).writeFloatLE(0.0, -1), RangeError);
   assert.deepStrictEqual(buf.toJSON().data, [0xff, 0xee, 0x00, 0x00, 0x00]);
   assert.strictEqual(buf.readIntBE(0, 5), -0x0012000000);
 }
-/*
+
 // Regression test for https://github.com/nodejs/node-v0.x-archive/issues/5482:
 // should throw but not assert in C++ land.
 common.expectsError(
@@ -899,7 +899,7 @@ common.expectsError(
     message: 'Unknown encoding: buffer'
   }
 );
-*/
+
 // Regression test for https://github.com/nodejs/node-v0.x-archive/issues/6111.
 // Constructing a buffer from another buffer should a) work, and b) not corrupt
 // the source buffer.

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -977,14 +977,14 @@ assert.strictEqual(SlowBuffer.prototype.offset, undefined);
   });
   assert.throws(() => Buffer.from(new ArrayBuffer(0), -1 >>> 0), errMsg);
 }
-/*
+
 // ParseArrayIndex() should reject values that don't fit in a 32 bits size_t.
 common.expectsError(() => {
   var a = Buffer.alloc(1);
   var b = Buffer.alloc(1);
   a.copy(b, 0, 0x100000000, 0x100000001);
 }, { code: undefined, type: RangeError, message: 'Index out of range' });
-*/
+
 // Unpooled buffer (replaces SlowBuffer)
 {
   var ubuf = Buffer.allocUnsafeSlow(10);

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -516,13 +516,13 @@ assert.deepStrictEqual(Buffer.from(' YWJvcnVtLg', 'base64'),
     assert.strictEqual(hexb2[i], hexb[i]);
   }
 }
-/*
+
 // Test single hex character is discarded.
 assert.strictEqual(Buffer.from('A', 'hex').length, 0);
 
 // Test that if a trailing character is discarded, rest of string is processed.
 assert.deepStrictEqual(Buffer.from('Abx', 'hex'), Buffer.from('Ab', 'hex'));
-*/
+
 // Test single base64 char encodes as 0.
 assert.strictEqual(Buffer.from('A', 'base64').length, 0);
 

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -459,10 +459,10 @@ assert.strictEqual(
   assert.strictEqual(b.toString('latin1', 0, pos),
                      'Madness?! This is node.js!');
 }
-/*
+
 // Regression test for https://github.com/nodejs/node/issues/3496.
 assert.strictEqual(Buffer.from('=bad'.repeat(1e4), 'base64').length, 0);
-*/
+
 // Regression test for https://github.com/nodejs/node/issues/11987.
 assert.deepStrictEqual(Buffer.from('w0  ', 'base64'),
                        Buffer.from('w0', 'base64'));

--- a/test/node/test-buffer-arraybuffer.js
+++ b/test/node/test-buffer-arraybuffer.js
@@ -17,7 +17,7 @@ var buf = Buffer.from(ab);
 assert.ok(buf instanceof Buffer);
 // For backwards compatibility of old .parent property test that if buf is not
 // a slice then .parent should be undefined.
-assert.equal(buf.parent, undefined);
+assert.equal(buf.parent, buf.buffer);
 assert.equal(buf.buffer, ab);
 assert.equal(buf.length, ab.byteLength);
 

--- a/test/node/test-buffer-arraybuffer.js
+++ b/test/node/test-buffer-arraybuffer.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-
+var common = require('../common');
 
 
 var assert = require('assert');
@@ -70,15 +70,15 @@ b.writeDoubleBE(11.11, 0, true);
   buf[0] = 9;
   assert.equal(ab[1], 9);
 
-  assert.throws(() => Buffer.from(ab.buffer, 6), (err) => {
-    assert(err instanceof RangeError);
-    assert(/'offset' is out of bounds/.test(err.message));
-    return true;
+  common.expectsError(() => Buffer.from(ab.buffer, 6), {
+    code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+    type: RangeError,
+    message: '"offset" is outside of buffer bounds'
   });
-  assert.throws(() => Buffer.from(ab.buffer, 3, 6), (err) => {
-    assert(err instanceof RangeError);
-    assert(/'length' is out of bounds/.test(err.message));
-    return true;
+  common.expectsError(() => Buffer.from(ab.buffer, 3, 6), {
+    code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+    type: RangeError,
+    message: '"length" is outside of buffer bounds'
   });
 }
 
@@ -98,15 +98,15 @@ b.writeDoubleBE(11.11, 0, true);
   buf[0] = 9;
   assert.equal(ab[1], 9);
 
-  assert.throws(() => Buffer(ab.buffer, 6), (err) => {
-    assert(err instanceof RangeError);
-    assert(/'offset' is out of bounds/.test(err.message));
-    return true;
+  common.expectsError(() => Buffer(ab.buffer, 6), {
+    code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+    type: RangeError,
+    message: '"offset" is outside of buffer bounds'
   });
-  assert.throws(() => Buffer(ab.buffer, 3, 6), (err) => {
-    assert(err instanceof RangeError);
-    assert(/'length' is out of bounds/.test(err.message));
-    return true;
+  common.expectsError(() => Buffer(ab.buffer, 3, 6), {
+    code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+    type: RangeError,
+    message: '"length" is outside of buffer bounds'
   });
 }
 

--- a/test/node/test-buffer-fill.js
+++ b/test/node/test-buffer-fill.js
@@ -1,6 +1,6 @@
 'use strict';
 var Buffer = require('../../').Buffer;
-
+const common = require('../common');
 
 
 var assert = require('assert');
@@ -137,10 +137,24 @@ testBufs('c8a26161', 8, 1, 'hex');
 testBufs('61c8b462c8b563c8b6', 4, -1, 'hex');
 testBufs('61c8b462c8b563c8b6', 4, 1, 'hex');
 testBufs('61c8b462c8b563c8b6', 12, 1, 'hex');
-// Make sure this operation doesn't go on forever
-buf1.fill('yKJh', 'hex');
-assert.throws(() => buf1.fill('\u0222', 'hex'));
 
+common.expectsError(() => {
+  const buf = Buffer.allocUnsafe(SIZE);
+
+  buf.fill('yKJh', 'hex');
+}, {
+  code: 'ERR_INVALID_ARG_VALUE',
+  type: TypeError
+});
+
+common.expectsError(() => {
+  const buf = Buffer.allocUnsafe(SIZE);
+
+  buf.fill('\u0222', 'hex');
+}, {
+  code: 'ERR_INVALID_ARG_VALUE',
+  type: TypeError
+});
 
 // BASE64
 testBufs('YWJj', 'ucs2');

--- a/test/node/test-buffer.js
+++ b/test/node/test-buffer.js
@@ -753,12 +753,6 @@ for (var i = 0; i < 256; i++) {
   assert.equal(hexb2[i], hexb[i]);
 }
 
-// Test single hex character throws TypeError
-// - https://github.com/nodejs/node/issues/6770
-assert.throws(function() {
-  Buffer.from('A', 'hex');
-}, TypeError);
-
 // Test single base64 char encodes as 0
 // assert.strictEqual(Buffer.from('A', 'base64').length, 0);
 
@@ -1461,34 +1455,6 @@ assert.throws(function() {
 
 // Regression test for https://github.com/nodejs/node/issues/649.
 assert.throws(function() { Buffer(1422561062959).toString('utf8'); });
-
-var ps = Buffer.poolSize;
-Buffer.poolSize = 0;
-assert.equal(Buffer(1).parent, undefined);
-Buffer.poolSize = ps;
-
-// Test Buffer.copy() segfault
-assert.throws(function() {
-  Buffer(10).copy();
-});
-
-var regErrorMsg = new RegExp('First argument must be a string, Buffer, ' +
-                               'ArrayBuffer, Array, or array-like object.');
-
-assert.throws(function() {
-  new Buffer();
-}, regErrorMsg);
-
-assert.throws(function() {
-  new Buffer(null);
-}, regErrorMsg);
-
-
-// Test prototype getters don't throw
-assert.equal(Buffer.prototype.parent, undefined);
-assert.equal(Buffer.prototype.offset, undefined);
-assert.equal(SlowBuffer.prototype.parent, undefined);
-assert.equal(SlowBuffer.prototype.offset, undefined);
 
 {
   // Test that large negative Buffer length inputs don't affect the pool offset.


### PR DESCRIPTION
This pull request updates the `test-buffer-alloc.js` from Node.js to the current upstream version.

I've used very granular commits which hopefully shows my workflow. I hope my approach is sound and the work was worth it.

This is part of #177.