### PR TITLE
Replace zuul with airtap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
-.zuul.yml
+.airtap.yml
 *.log
 node_modules/

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,3 @@
-.zuul.yml
+.airtap.yml
 bin/
 perf/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: node_js
 node_js:
 - lts/*
 sudo: false
+addons:
+  sauce_connect: true
+  hosts:
+    - airtap.local
 env:
   global:
   - secure: AUsK+8fYSpwIMHcVt8Mu9SpG9RPHp4XDAwCQfpU3d5U65q8OVVC6C+XjvnNmEd2PoEJRHem8ZXEyRVfGM1sttKZLZP70TEKZOpOiRQnZiTQCAJ92TfGsDj/F4LoWSjUZUpfeg9b3iSp8G5dVw3+q9QZPIu6eykASK6bfcg//Cyg=

--- a/README.md
+++ b/README.md
@@ -381,13 +381,13 @@ To test locally in a browser, you can run:
     npm run test-browser-es5-local # For ES5 browsers that don't support ES6
     npm run test-browser-es6-local # For ES6 compliant browsers
 
-This will print out a URL that you can then open in a browser to run the tests, using [Zuul](https://github.com/defunctzombie/zuul).
+This will print out a URL that you can then open in a browser to run the tests, using [airtap](https://www.npmjs.com/package/airtap).
 
 To run automated browser tests using Saucelabs, ensure that your `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` environment variables are set, then run:
 
     npm test
 
-This is what's run in Travis, to check against various browsers. The list of browsers is kept in the `.zuul.yml` file.
+This is what's run in Travis, to check against various browsers. The list of browsers is kept in the `bin/airtap-es5.yml` and `bin/airtap-es6.yml` files.
 
 ## JavaScript Standard Style
 

--- a/bin/airtap-es5.yml
+++ b/bin/airtap-es5.yml
@@ -1,4 +1,5 @@
-ui: tape
+sauce_connect: true
+loopback: airtap.local
 browsers:
   - name: ie
     version: latest

--- a/bin/airtap-es6.yml
+++ b/bin/airtap-es6.yml
@@ -1,4 +1,5 @@
-ui: tape
+sauce_connect: true
+loopback: airtap.local
 browsers:
   - name: chrome
     version: -1..latest

--- a/bin/test.js
+++ b/bin/test.js
@@ -17,24 +17,24 @@ node.on('close', function (code) {
 })
 
 function runBrowserTests () {
-  var zuulYmlPath = path.join(__dirname, '..', '.zuul.yml')
+  var airtapYmlPath = path.join(__dirname, '..', '.airtap.yml')
 
-  writeES5ZuulYml()
+  writeES5AirtapYml()
   cp.spawn('npm', ['run', 'test-browser-es5'], { stdio: 'inherit' })
     .on('close', function (code) {
       if (code !== 0) process.exit(code)
-      writeES6ZuulYml()
+      writeES6AirtapYml()
       cp.spawn('npm', ['run', 'test-browser-es6'], { stdio: 'inherit' })
         .on('close', function (code) {
           process.exit(code)
         })
     })
 
-  function writeES5ZuulYml () {
-    fs.writeFileSync(zuulYmlPath, fs.readFileSync(path.join(__dirname, 'zuul-es5.yml')))
+  function writeES5AirtapYml () {
+    fs.writeFileSync(airtapYmlPath, fs.readFileSync(path.join(__dirname, 'airtap-es5.yml')))
   }
 
-  function writeES6ZuulYml () {
-    fs.writeFileSync(zuulYmlPath, fs.readFileSync(path.join(__dirname, 'zuul-es6.yml')))
+  function writeES6AirtapYml () {
+    fs.writeFileSync(airtapYmlPath, fs.readFileSync(path.join(__dirname, 'airtap-es6.yml')))
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "ieee754": "^1.1.4"
   },
   "devDependencies": {
+    "airtap": "0.0.1",
     "benchmark": "^2.0.0",
     "browserify": "^14.0.0",
     "concat-stream": "^1.4.7",
@@ -29,8 +30,7 @@
     "standard": "*",
     "tape": "^4.0.0",
     "through2": "^2.0.0",
-    "uglify-js": "^2.7.3",
-    "zuul": "^3.0.0"
+    "uglify-js": "^2.7.3"
   },
   "homepage": "https://github.com/feross/buffer",
   "jspm": {
@@ -60,10 +60,10 @@
     "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
     "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
     "test": "standard && node ./bin/test.js",
-    "test-browser-es5": "zuul --ui tape -- test/*.js",
-    "test-browser-es5-local": "zuul --ui tape --local -- test/*.js",
-    "test-browser-es6": "zuul --ui tape -- test/*.js test/node/*.js",
-    "test-browser-es6-local": "zuul --ui tape --local -- test/*.js test/node/*.js",
+    "test-browser-es5": "airtap -- test/*.js",
+    "test-browser-es5-local": "airtap --local -- test/*.js",
+    "test-browser-es6": "airtap -- test/*.js test/node/*.js",
+    "test-browser-es6-local": "airtap --local -- test/*.js test/node/*.js",
     "test-node": "tape test/*.js test/node/*.js",
     "update-authors": "./bin/update-authors.sh"
   },


### PR DESCRIPTION
Testing out a replacement package for zuul called airtap.

https://www.npmjs.com/package/airtap

Much simpler than zuul in that it only supports tap/tape, actively maintained, doesn't rely on the unreliable localtunnel service.

It may have big breaking changes before V1, but it's already so much more reliable that I think it's worth it.