### PR TITLE
fix/cast boolean to unsigned with alloc

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,8 +198,9 @@ function alloc (size, fill, encoding) {
     // prevents accidentally sending in a number that would
     // be interpretted as a start offset.
     return typeof encoding === 'string'
-      ? createBuffer(size).fill(fill, encoding)
-      : createBuffer(size).fill(fill)
+      // cast boolean to unsigned
+      ? createBuffer(size).fill(typeof fill === 'boolean' ? Number(fill) : fill, encoding)
+      : createBuffer(size).fill(typeof fill === 'boolean' ? Number(fill) : fill)
   }
   return createBuffer(size)
 }
@@ -298,6 +299,10 @@ function fromObject (obj) {
     obj.copy(buf, 0, 0, len)
     return buf
   }
+
+  // if (typeof obj === 'boolean') {
+  //   return fromArrayLike([obj ? 0x01 : 0x00])
+  // }
 
   if (obj.length !== undefined) {
     if (typeof obj.length !== 'number' || numberIsNaN(obj.length)) {

--- a/index.js
+++ b/index.js
@@ -300,10 +300,6 @@ function fromObject (obj) {
     return buf
   }
 
-  // if (typeof obj === 'boolean') {
-  //   return fromArrayLike([obj ? 0x01 : 0x00])
-  // }
-
   if (obj.length !== undefined) {
     if (typeof obj.length !== 'number' || numberIsNaN(obj.length)) {
       return createBuffer(0)

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -183,6 +183,17 @@ assert.doesNotThrow(() => Buffer.alloc(1).write('', 1, 0));
 }
 
 {
+  // cast boolean to unsigned
+  const a = Buffer.alloc(1, true);
+  assert.ok(a.length === 1);
+  assert.ok(a[0] === 1);
+
+  const b = Buffer.alloc(1, false);
+  assert.ok(b.length === 1);
+  assert.ok(b[0] === 0);
+}
+
+{
   // also from a non-pooled instance
   const b = Buffer.allocUnsafeSlow(5);
   const c = b.slice(0, 4);


### PR DESCRIPTION
Cast booleans to unsigned when `Buffer.alloc(1, true)`, which is a default behaviour in nodejs v8.