### PR TITLE
Use lookup table for faster hex encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -1068,7 +1068,7 @@ function hexSlice (buf, start, end) {
 
   var out = ''
   for (var i = start; i < end; ++i) {
-    out += toHex(buf[i])
+    out += hexSliceNewLookupTable[buf[i]]
   }
   return out
 }
@@ -1654,11 +1654,6 @@ function base64clean (str) {
   return str
 }
 
-function toHex (n) {
-  if (n < 16) return '0' + n.toString(16)
-  return n.toString(16)
-}
-
 function utf8ToBytes (string, units) {
   units = units || Infinity
   var codePoint
@@ -1788,3 +1783,17 @@ function numberIsNaN (obj) {
   // For IE11 support
   return obj !== obj // eslint-disable-line no-self-compare
 }
+
+// Create lookup table for `toString('hex')`
+// See: https://github.com/feross/buffer/issues/219
+var hexSliceNewLookupTable = (function () {
+  var alphabet = '0123456789abcdef'
+  var table = new Array(256)
+  for (var i = 0; i < 16; ++i) {
+    var i16 = i * 16
+    for (var j = 0; j < 16; ++j) {
+      table[i16 + j] = alphabet[i] + alphabet[j]
+    }
+  }
+  return table
+})()

--- a/index.js
+++ b/index.js
@@ -1068,7 +1068,7 @@ function hexSlice (buf, start, end) {
 
   var out = ''
   for (var i = start; i < end; ++i) {
-    out += hexSliceNewLookupTable[buf[i]]
+    out += hexSliceLookupTable[buf[i]]
   }
   return out
 }
@@ -1786,7 +1786,7 @@ function numberIsNaN (obj) {
 
 // Create lookup table for `toString('hex')`
 // See: https://github.com/feross/buffer/issues/219
-var hexSliceNewLookupTable = (function () {
+var hexSliceLookupTable = (function () {
   var alphabet = '0123456789abcdef'
   var table = new Array(256)
   for (var i = 0; i < 16; ++i) {


### PR DESCRIPTION
Lookup table faster ~9-12 times than toString('hex') for each byte. See https://github.com/feross/buffer/issues/219

<hr>
Benchmarks for generating lookup table:
<details>
<summary>code here</summary>

```js
function g11 () {
  var table = []
  for (var i = 0; i < 256; ++i) {
    table[i] = ('0' + i.toString(16)).slice(-2)
  }
  return table
}

function g12 () {
  var table = []
  for (var i = 0; i < 256; ++i) {
    table.push(('0' + i.toString(16)).slice(-2))
  }
  return table
}

function g13 () {
  var table = new Array(256)
  for (var i = 0; i < 256; ++i) {
    table[i] = ('0' + i.toString(16)).slice(-2)
  }
  return table
}

function g211 () {
  var alphabet = '0123456789abcdef'
  var table = []
  for (var i = 0; i < 16; ++i) {
    for (var j = 0; j < 16; ++j) {
      table[i * 16 + j] = alphabet[i] + alphabet[j]
    }
  }
  return table
}

function g212 () {
  var alphabet = '0123456789abcdef'
  var table = []
  for (var i = 0; i < 16; ++i) {
    var i16 = i * 16
    for (var j = 0; j < 16; ++j) {
      table[i16 + j] = alphabet[i] + alphabet[j]
    }
  }
  return table
}

function g22 () {
  var alphabet = '0123456789abcdef'
  var table = []
  for (var i = 0; i < 16; ++i) {
    for (var j = 0; j < 16; ++j) {
      table.push(alphabet[i] + alphabet[j])
    }
  }
  return table
}

function g231 () {
  var alphabet = '0123456789abcdef'
  var table = new Array(256)
  for (var i = 0; i < 16; ++i) {
    for (var j = 0; j < 16; ++j) {
      table[i * 16 + j] = alphabet[i] + alphabet[j]
    }
  }
  return table
}

function g232 () {
  var alphabet = '0123456789abcdef'
  var table = new Array(256)
  for (var i = 0; i < 16; ++i) {
    var i16 = i * 16
    for (var j = 0; j < 16; ++j) {
      table[i16 + j] = alphabet[i] + alphabet[j]
    }
  }
  return table
}

function measure (name, fn, count = 1e3) {
  ;%DeoptimizeFunction(fn)
  ;%NeverOptimizeFunction(fn)

  console.time(name)
  for (var i = 0; i < count; ++i) fn()
  console.timeEnd(name)

  // console.log(%GetOptimizationStatus(fn))
}

measure('toString index', g11)
measure('toString push', g12)
measure('toString index predefined', g13)
measure('array index', g211)
measure('array index i16', g212)
measure('array push', g22)
measure('array predefined', g231)
measure('array predefined i16', g232)


// // not optimized
// $ node --allow-natives-syntax ./t1.js 
// toString index: 52.397ms
// toString push: 51.300ms
// toString index predefined: 46.029ms
// array index: 18.343ms
// array index i16: 17.366ms
// array push: 18.097ms
// array predefined: 17.889ms
// array predefined i16: 15.965ms
// // optimized: kOptimized | kTurboFanned
// $ node --allow-natives-syntax ./t1.js 
// toString index: 32.572ms
// toString push: 34.944ms
// toString index predefined: 27.594ms
// array index: 9.485ms
// array index i16: 8.989ms
// array push: 6.545ms
// array predefined: 9.969ms
// array predefined i16: 8.337ms
```
</details>

If we not allow V8 optimize function (because functions hot, they will be JIT-ed) fastest way:
```js
function g232 () {
  var alphabet = '0123456789abcdef'
  var table = new Array(256)
  for (var i = 0; i < 16; ++i) {
    var i16 = i * 16
    for (var j = 0; j < 16; ++j) {
      table[i16 + j] = alphabet[i] + alphabet[j]
    }
  }
  return table
}
```
Also this should be packed smi array what should give additional performance (not sure).

<hr>
Benchmarks for `toString('hex')` new-vs-old:

<details>
<summary>Code here</summary>

```js
// Current Buffer way
function toHex (n) {
  if (n < 16) return '0' + n.toString(16)
  return n.toString(16)
}

function hexSlice (buf, start, end) {
  var len = buf.length

  if (!start || start < 0) start = 0
  if (!end || end < 0 || end > len) end = len

  var out = ''
  for (var i = start; i < end; ++i) {
    out += toHex(buf[i])
  }
  return out
}

// New Buffer way
var hexSliceNewLookupTable = (function () {
  var alphabet = '0123456789abcdef'
  var table = new Array(256)
  for (var i = 0; i < 16; ++i) {
    var i16 = i * 16
    for (var j = 0; j < 16; ++j) {
      table[i16 + j] = alphabet[i] + alphabet[j]
    }
  }
  return table
})()

function hexSliceNew (buf, start, end) {
  var len = buf.length

  if (!start || start < 0) start = 0
  if (!end || end < 0 || end > len) end = len

  var out = ''
  for (var i = start; i < end; ++i) {
    out += hexSliceNewLookupTable[buf[i]]
  }
  return out
}

// Measure it
function measure (name, fn, buffers) {
  console.time(name)
  for (var i = 0; i < buffers.length; ++i) fn(buffers[i])
  console.timeEnd(name)
}

// data
var XorShift128Plus = require('xorshift.js').XorShift128Plus
var prng = new XorShift128Plus('ba4ebf7a16fc931c401f6c7e12c61eaa')
var buffers = new Array(1e4)
for (var i = 0; i < buffers.length; ++i) buffers[i] = prng.randomBytes(1024)

measure('hexSliceOld', hexSlice, buffers)
measure('hexSliceNew', hexSliceNew, buffers)

// // $ node ./t2.js 
// hexSliceOld: 955.224ms
// hexSliceNew: 79.119ms
```
</details>

Current way slowly ~12 times. Tested 10k buffer with 1024 bytes: 995ms vs 79ms.