### PR TITLE
packed hexSliceLookupTable instead holey

### DIFF
--- a/index.js
+++ b/index.js
@@ -1788,11 +1788,10 @@ function numberIsNaN (obj) {
 // See: https://github.com/feross/buffer/issues/219
 var hexSliceLookupTable = (function () {
   var alphabet = '0123456789abcdef'
-  var table = new Array(256)
+  var table = []
   for (var i = 0; i < 16; ++i) {
-    var i16 = i * 16
     for (var j = 0; j < 16; ++j) {
-      table[i16 + j] = alphabet[i] + alphabet[j]
+      table.push(alphabet[i] + alphabet[j])
     }
   }
   return table


### PR DESCRIPTION
Lookup table was added in #245 
I made wrong assumption about packed/holey array. In #245 was holey, packed by benchmark give up to 10%.

Code for bench:
```js
const { randomBytes } = require('crypto')

var hexSliceLookupTable1 = (function () {
  var alphabet = '0123456789abcdef'
  var table = new Array(256)
  for (var i = 0; i < 16; ++i) {
    var i16 = i * 16
    for (var j = 0; j < 16; ++j) {
      table[i16 + j] = alphabet[i] + alphabet[j]
    }
  }
  return table
})()

var hexSliceLookupTable2 = (function () {
  var alphabet = '0123456789abcdef'
  var table = []
  for (var i = 0; i < 16; ++i) {
    var i16 = i * 16
    for (var j = 0; j < 16; ++j) {
      table.push(alphabet[i] + alphabet[j])
    }
  }
  return table
})()

console.log(`%HasPackedElements(hexSliceLookupTable1) = ${%HasPackedElements(hexSliceLookupTable1)}`)
console.log(`%HasHoleyElements(hexSliceLookupTable1) = ${%HasHoleyElements(hexSliceLookupTable1)}`)

console.log(`%HasPackedElements(hexSliceLookupTable2) = ${%HasPackedElements(hexSliceLookupTable2)}`)
console.log(`%HasHoleyElements(hexSliceLookupTable2) = ${%HasHoleyElements(hexSliceLookupTable2)}`)


function hexSlice (buf, table) {
  var out = ''
  for (var i = 0; i < buf.length; ++i) {
    out += table[buf[i]]
  }
  return out
}

for (let i = 0; i < 1e3; ++i) {
  hexSlice(randomBytes(32), hexSliceLookupTable1)
  hexSlice(randomBytes(32), hexSliceLookupTable2)
}
console.log(`%GetOptimizationStatus(hexSlice) = ${%GetOptimizationStatus(hexSlice)}, is optimized: ${!!(%GetOptimizationStatus(hexSlice) & (1 << 4))}`)


const buffer = randomBytes(100 * 1024)

console.time('hexSliceLookupTable1')
for (let i = 0; i < 1e3; ++i) hexSlice(buffer, hexSliceLookupTable1)
console.timeEnd('hexSliceLookupTable1')

console.time('hexSliceLookupTable2')
for (let i = 0; i < 1e3; ++i) hexSlice(buffer, hexSliceLookupTable2)
console.timeEnd('hexSliceLookupTable2')
```

```bash
$ node --allow-natives-syntax x.js 
%HasPackedElements(hexSliceLookupTable1) = false
%HasHoleyElements(hexSliceLookupTable1) = true
%HasPackedElements(hexSliceLookupTable2) = true
%HasHoleyElements(hexSliceLookupTable2) = false
%GetOptimizationStatus(hexSlice) = 49, is optimized: true
hexSliceLookupTable1: 788.261ms
hexSliceLookupTable2: 761.303ms
```