### PR TITLE
Different behaviour from node.js for utf16leSlice

### DIFF
--- a/index.js
+++ b/index.js
@@ -1076,7 +1076,8 @@ function hexSlice (buf, start, end) {
 function utf16leSlice (buf, start, end) {
   var bytes = buf.slice(start, end)
   var res = ''
-  for (var i = 0; i < bytes.length; i += 2) {
+  // If bytes.length is odd, the last 8 bits must be ignored (same as node.js)
+  for (var i = 0; i < bytes.length - 1; i += 2) {
     res += String.fromCharCode(bytes[i] + (bytes[i + 1] * 256))
   }
   return res

--- a/test/to-string.js
+++ b/test/to-string.js
@@ -33,6 +33,14 @@ test('utf16le to utf16', function (t) {
   t.end()
 })
 
+test('utf16le to utf16 with odd byte length input', function (t) {
+  t.equal(
+    new B(new B('abcde', 'utf8').toString('utf16le'), 'utf16le').toString('utf8'),
+    'abcd'
+  )
+  t.end()
+})
+
 test('utf16le to hex', function (t) {
   t.equal(
     new B('abcd', 'utf16le').toString('hex'),


### PR DESCRIPTION
# Problem
```js
const oddLengthBuffer = Buffer.from('abcde', 'utf8')
console.log(Buffer.from(oddLengthBuffer.toString('utf16le'), 'utf16le').toString('utf8')) // ‘abcd’ in Node.js and ‘abcd\x00\x00’ with polyfill
```
This comes from accessing n+1-th element of a Buffer of size n in utf16leSlice.
# Solution
We omit the last byte for an odd length buffer when encoding to UTF16-LE