### PR TITLE
Add fromArrayView for TypedArrays and DataViews. Fast path for Uint8A…

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ function from (value, encodingOrOffset, length) {
   }
 
   if (ArrayBuffer.isView(value)) {
-    return fromArrayLike(value)
+    return fromArrayView(value)
   }
 
   if (value == null) {
@@ -267,6 +267,14 @@ function fromArrayLike (array) {
     buf[i] = array[i] & 255
   }
   return buf
+}
+
+function fromArrayView (arrayView) {
+  if (isInstance(arrayView, Uint8Array)) {
+    var copy = Uint8Array.from(arrayView)
+    return fromArrayBuffer(copy.buffer, copy.byteOffset, copy.byteLength)
+  }
+  return fromArrayLike(arrayView)
 }
 
 function fromArrayBuffer (array, byteOffset, length) {

--- a/index.js
+++ b/index.js
@@ -416,12 +416,16 @@ Buffer.concat = function concat (list, length) {
   for (i = 0; i < list.length; ++i) {
     var buf = list[i]
     if (isInstance(buf, Uint8Array)) {
-      buf = Buffer.from(buf)
-    }
-    if (!Buffer.isBuffer(buf)) {
+      Uint8Array.prototype.set.call(
+        buffer,
+        buf,
+        pos
+      )
+    } else if (!Buffer.isBuffer(buf)) {
       throw new TypeError('"list" argument must be an Array of Buffers')
+    } else {
+      buf.copy(buffer, pos)
     }
-    buf.copy(buffer, pos)
     pos += buf.length
   }
   return buffer


### PR DESCRIPTION
I'm using webtorrent in Android (via a quickjs runtime that embeds into java).

I noticed that performance was extremely slow, and found that the torrent piece byte arrays were being copied here, in a JS for loop, treating Uint8Arrays as if they were just normal arrays. Pieces are a couple MB, so every time Buffer.from was called on a piece, it would loop millions of times, in JavaScript, to do the copy.

Given that the underlying Array view is a Uint8Array, it's possible to use the ArrayBuffer fast path here, and allow the runtime to do the memcpy (be it browser or quickjs).

This patch ended up resolving all my perf issues.