### PR TITLE
[Fix] `Symbol.for` is a syntax error in older browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@
 var base64 = require('base64-js')
 var ieee754 = require('ieee754')
 var customInspectSymbol =
-  (typeof Symbol === 'function' && typeof Symbol.for === 'function')
-    ? Symbol.for('nodejs.util.inspect.custom')
+  (typeof Symbol === 'function' && typeof Symbol['for'] === 'function')
+    ? Symbol['for']('nodejs.util.inspect.custom')
     : null
 
 exports.Buffer = Buffer


### PR DESCRIPTION
For example, Opera 10.6.

Introduced in #204; affects v5.4.0+.