### PR TITLE
Fix Buffer.from for SharedArrayBuffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,6 +142,11 @@ function from (value, encodingOrOffset, length) {
     return fromArrayBuffer(value, encodingOrOffset, length)
   }
 
+  if (isInstance(value, SharedArrayBuffer) ||
+      (value && isInstance(value.buffer, SharedArrayBuffer))) {
+    return fromArrayBuffer(value, encodingOrOffset, length)
+  }
+
   if (typeof value === 'number') {
     throw new TypeError(
       'The "value" argument must not be of type number. Received type number'

--- a/package.json
+++ b/package.json
@@ -74,6 +74,9 @@
       "test/common.js",
       "test/_polyfill.js",
       "perf/**/*.js"
+    ],
+    "globals": [
+      "SharedArrayBuffer"
     ]
   }
 }

--- a/test/node/test-buffer-alloc.js
+++ b/test/node/test-buffer-alloc.js
@@ -51,6 +51,14 @@ assert.strictEqual(0, d.length);
     assert.deepStrictEqual(value, ui32[key]);
   }
 }
+{
+  const sab = new SharedArrayBuffer(Uint8Array.BYTES_PER_ELEMENT * 4);
+  const ui32 = new Uint8Array(sab).fill(42);
+  const e = Buffer(sab);
+  for (const [key, value] of e.entries()) {
+    assert.deepStrictEqual(value, ui32[key]);
+  }
+}
 
 // Test invalid encoding for Buffer.toString
 assert.throws(() => b.toString('invalid'),


### PR DESCRIPTION
Closes https://github.com/feross/buffer/issues/256

`SharedArrayBuffer` has the same properties as `ArrayBuffer` (`new Uint8Array(sab)` works, `sab.byteLength` exists), therefore `fromArrayBuffer` can be used.