### PR TITLE
Remove unneeded Symbol.species code

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,17 +108,6 @@ function Buffer (arg, encodingOrOffset, length) {
   return from(arg, encodingOrOffset, length)
 }
 
-// Fix subarray() in ES2016. See: https://github.com/feross/buffer/pull/97
-if (typeof Symbol !== 'undefined' && Symbol.species != null &&
-    Buffer[Symbol.species] === Buffer) {
-  Object.defineProperty(Buffer, Symbol.species, {
-    value: null,
-    configurable: true,
-    enumerable: false,
-    writable: false
-  })
-}
-
 Buffer.poolSize = 8192 // not used by this implementation
 
 function from (value, encodingOrOffset, length) {


### PR DESCRIPTION
We now handle calls like:

new Buffer(arraybuffer, 2, 8) so there's no need for this workaround originally implemented in: https://github.com/feross/buffer/pull/97

More info: https://bugs.chromium.org/p/v8/issues/detail?id=4665#c4

Fixes #260. Supersedes #261