### PR TITLE
Make Buffer more compliant with official implementation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,9 +3,9 @@ export class Buffer extends Uint8Array {
     write(string: string, offset?: number, length?: number, encoding?: string): number;
     toString(encoding?: string, start?: number, end?: number): string;
     toJSON(): { type: 'Buffer', data: any[] };
-    equals(otherBuffer: Buffer): boolean;
+    equals(otherBuffer: Uint8Array): boolean;
     compare(otherBuffer: Uint8Array, targetStart?: number, targetEnd?: number, sourceStart?: number, sourceEnd?: number): number;
-    copy(targetBuffer: Buffer, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
+    copy(targetBuffer: Uint8Array, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
     slice(start?: number, end?: number): Buffer;
     writeUIntLE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;
     writeUIntBE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;
@@ -56,9 +56,9 @@ export class Buffer extends Uint8Array {
     writeDoubleLE(value: number, offset: number, noAssert?: boolean): number;
     writeDoubleBE(value: number, offset: number, noAssert?: boolean): number;
     fill(value: any, offset?: number, end?: number): this;
-    indexOf(value: string | number | Buffer, byteOffset?: number, encoding?: string): number;
-    lastIndexOf(value: string | number | Buffer, byteOffset?: number, encoding?: string): number;
-    includes(value: string | number | Buffer, byteOffset?: number, encoding?: string): boolean;
+    indexOf(value: string | number | Uint8Array, byteOffset?: number, encoding?: string): number;
+    lastIndexOf(value: string | number | Uint8Array, byteOffset?: number, encoding?: string): number;
+    includes(value: string | number | Uint8Array, byteOffset?: number, encoding?: string): boolean;
 
     /**
      * Allocates a new buffer containing the given {str}.
@@ -122,7 +122,7 @@ export class Buffer extends Uint8Array {
      *
      * @param buffer
      */
-    static from(buffer: Buffer | Uint8Array): Buffer;
+    static from(buffer: Uint8Array): Buffer;
     /**
      * Creates a new Buffer containing the given JavaScript string {str}.
      * If provided, the {encoding} parameter identifies the character encoding.
@@ -176,7 +176,7 @@ export class Buffer extends Uint8Array {
      *    If parameter is omitted, buffer will be filled with zeros.
      * @param encoding encoding used for call to buf.fill while initializing
      */
-    static alloc(size: number, fill?: string | Buffer | number, encoding?: string): Buffer;
+    static alloc(size: number, fill?: string | Uint8Array | number, encoding?: string): Buffer;
     /**
      * Allocates a new buffer of {size} octets, leaving memory not initialized, so the contents
      * of the newly created Buffer are unknown and may contain sensitive data.

--- a/index.js
+++ b/index.js
@@ -609,7 +609,7 @@ Buffer.prototype.toString = function toString () {
 Buffer.prototype.toLocaleString = Buffer.prototype.toString
 
 Buffer.prototype.equals = function equals (b) {
-  if (!Buffer.isBuffer(b)) throw new TypeError('Argument must be a Buffer')
+  if (!Buffer.isBuffer(b) && !(b instanceof Uint8Array)) throw new TypeError('Argument must be a Buffer')
   if (this === b) return true
   return Buffer.compare(this, b) === 0
 }
@@ -1688,7 +1688,7 @@ Buffer.prototype.writeDoubleBE = function writeDoubleBE (value, offset, noAssert
 
 // copy(targetBuffer, targetStart=0, sourceStart=0, sourceEnd=buffer.length)
 Buffer.prototype.copy = function copy (target, targetStart, start, end) {
-  if (!Buffer.isBuffer(target)) throw new TypeError('argument should be a Buffer')
+  if (!Buffer.isBuffer(target) && !(target instanceof Uint8Array)) throw new TypeError('argument should be a Buffer')
   if (!start) start = 0
   if (!end && end !== 0) end = this.length
   if (targetStart >= target.length) targetStart = target.length

--- a/test/equals.js
+++ b/test/equals.js
@@ -1,0 +1,18 @@
+const B = require('../').Buffer
+const test = require('tape')
+const { randomBytes } = require('crypto')
+
+test('buffer.equals', function (t) {
+  const a = B.from(randomBytes(32))
+  const b = B.from(randomBytes(64))
+  const c = B.from(randomBytes(128))
+  const d = B.from(randomBytes(256))
+  const e = B.from(randomBytes(512))
+
+  t.assert(a.equals(new Uint8Array(a.buffer)))
+  t.assert(b.equals(new Uint8Array(b.buffer)))
+  t.assert(c.equals(new Uint8Array(c.buffer)))
+  t.assert(d.equals(new Uint8Array(d.buffer)))
+  t.assert(e.equals(new Uint8Array(e.buffer)))
+  t.end()
+})

--- a/test/methods.js
+++ b/test/methods.js
@@ -1,5 +1,6 @@
 const B = require('../').Buffer
 const test = require('tape')
+const { randomBytes } = require('crypto')
 
 test('buffer.toJSON', function (t) {
   const data = [1, 2, 3, 4]
@@ -26,6 +27,12 @@ test('buffer.copy', function (t) {
     buf2.toString('ascii', 0, 25),
     '!!!!!!!!qrst!!!!!!!!!!!!!'
   )
+
+  const buf3 = Buffer.from([1, 2, 3])
+  const buf4 = new Uint8Array(3)
+  buf3.copy(buf4)
+  t.ok(buf3.equals(buf4))
+
   t.end()
 })
 
@@ -136,5 +143,15 @@ test('buffer.slice out of range', function (t) {
   t.plan(2)
   t.equal((new B('hallo')).slice(0, 10).toString(), 'hallo')
   t.equal((new B('hallo')).slice(10, 2).toString(), '')
+  t.end()
+})
+
+test('buffer.includes', function (t) {
+  const bytes1 = new Uint8Array([54, 12, 21])
+  t.ok(B.from(bytes1), bytes1)
+
+  const size = 512
+  const bytes2 = randomBytes(size)
+  t.ok(B.alloc((size * 2) - 1, bytes2), bytes2)
   t.end()
 })

--- a/test/static.js
+++ b/test/static.js
@@ -14,3 +14,15 @@ test('Buffer.isBuffer', function (t) {
   t.equal(B.isBuffer('hey'), false)
   t.end()
 })
+
+test('Buffer.alloc', function (t) {
+  t.notStrictEqual(
+    B.alloc(10, new Uint8Array([1, 2, 3])),
+    Buffer.from(new Uint8Array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1]))
+  )
+  t.notStrictEqual(
+    B.alloc(1),
+    Buffer.from(new Uint8Array([0]))
+  )
+  t.end()
+})


### PR DESCRIPTION
This fixes all the instances where Uint8Array is a valid parameter but errors due to the parameter "not being a buffer"