### PR TITLE
Updates README.md with more inclusive language

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ Alternatively, use the [`to-arraybuffer`](https://www.npmjs.com/package/to-array
 
 See perf tests in `/perf`.
 
-`BrowserBuffer` is the browser `buffer` module (this repo). `Uint8Array` is included as a
-sanity check (since `BrowserBuffer` uses `Uint8Array` under the hood, `Uint8Array` will
+`BrowserBuffer` is the browser `buffer` module (this repo). `Uint8Array` is included as an
+additional check (since `BrowserBuffer` uses `Uint8Array` under the hood, `Uint8Array` will
 always be at least a bit faster). Finally, `NodeBuffer` is the node.js buffer module,
 which is included to compare against.
 


### PR DESCRIPTION
This change replaces "a sanity check" with "an additional check."

Justification:

> The phrase sanity check is ableist, and unnecessarily references mental health in our code bases. It denotes that people with mental illnesses are inferior, wrong, or incorrect, and the phrase sanity continues to be used by employers and other individuals to discriminate against these people.

Via [Ableist language](https://gist.github.com/seanmhanson/fe370c2d8bd2b3228680e38899baf5cc#:~:text=The%20phrase%20sanity%20check%20is,to%20discriminate%20against%20these%20people.)

See also: [Google developer documentation style guide: Writing inclusive documentation](https://developers.google.com/style/inclusive-documentation)