### PR TITLE
Accept Uint8array for copy target

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ export class Buffer extends Uint8Array {
     toJSON(): { type: 'Buffer', data: any[] };
     equals(otherBuffer: Buffer): boolean;
     compare(otherBuffer: Uint8Array, targetStart?: number, targetEnd?: number, sourceStart?: number, sourceEnd?: number): number;
-    copy(targetBuffer: Buffer, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
+    copy(targetBuffer: Buffer | Uint8Array, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
     slice(start?: number, end?: number): Buffer;
     writeUIntLE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;
     writeUIntBE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;

--- a/index.js
+++ b/index.js
@@ -1690,7 +1690,7 @@ Buffer.prototype.writeDoubleBE = function writeDoubleBE (value, offset, noAssert
 
 // copy(targetBuffer, targetStart=0, sourceStart=0, sourceEnd=buffer.length)
 Buffer.prototype.copy = function copy (target, targetStart, start, end) {
-  if (!Buffer.isBuffer(target)) throw new TypeError('argument should be a Buffer')
+  if (!(Buffer.isBuffer(target) || target instanceof Uint8Array)) throw new TypeError('argument should be a Buffer')
   if (!start) start = 0
   if (!end && end !== 0) end = this.length
   if (targetStart >= target.length) targetStart = target.length

--- a/test/methods.js
+++ b/test/methods.js
@@ -26,6 +26,17 @@ test('buffer.copy', function (t) {
     buf2.toString('ascii', 0, 25),
     '!!!!!!!!qrst!!!!!!!!!!!!!'
   )
+
+  const u8buf = new Uint8Array(26)
+  u8buf.fill(35) // ASCII #
+
+  buf1.copy(u8buf, 8, 20, 24)
+
+  t.equal(
+    new TextDecoder().decode(u8buf.slice(0, 25)),
+    '########uvwx#############'
+  )
+
   t.end()
 })
 


### PR DESCRIPTION
It is convenient if `copy` method accept `Uint8Array` as a target buffer.

I'm using `memfs` module
and I wonder if `read` method can accept `Uint8Array` directly:
https://github.com/streamich/memfs/blob/8d9e5332efb800a673f5f3c9702817b7d359ce1a/src/node.ts#L135
