### PR TITLE
Remove standard from tests, prefer node testing for first-pass CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/feross/buffer/issues"
   },
   "contributors": [
+    "Daniel Cousens",
     "Romain Beauxis <toots@rastageeks.org>",
     "James Halliday <mail@substack.net>"
   ],
@@ -60,12 +61,11 @@
     "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
     "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
     "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
-    "test": "standard && node ./bin/test.js",
+    "test": "tape test/*.js test/node/*.js",
     "test-browser-old": "airtap -- test/*.js",
     "test-browser-old-local": "airtap --local -- test/*.js",
     "test-browser-new": "airtap -- test/*.js test/node/*.js",
     "test-browser-new-local": "airtap --local -- test/*.js test/node/*.js",
-    "test-node": "tape test/*.js test/node/*.js",
     "update-authors": "./bin/update-authors.sh"
   },
   "standard": {


### PR DESCRIPTION
Follow up to https://github.com/feross/buffer/pull/331

`standard` was in the `test` target, which I think is misleading when we can differentiate that in the GitHub pull requests using workflows (as I did in https://github.com/feross/buffer/pull/331).

Additionally, our default `test` should prioritise `node` for now, until I can update the CI with an alternative to `airtap` (or at least, fix `airtap`) for browser testing (our primary priority and userbase).