### PR TITLE
Fix failing tests for #303 (unreleased)

### DIFF
--- a/test/node/test-buffer-badhex.js
+++ b/test/node/test-buffer-badhex.js
@@ -21,6 +21,7 @@ const assert = require('assert');
   assert.strictEqual(buf.write('abc def01', 0, 'hex'), 1);
   assert.deepStrictEqual(buf, new Buffer([0xab, 0, 0, 0]));
   assert.strictEqual(buf.toString('hex'), 'ab000000');
+  assert.deepStrictEqual(Buffer.from('abc def01', 'hex'), Buffer.from([0xab]));
 
   const copy = Buffer.from(buf.toString('hex'), 'hex');
   assert.strictEqual(buf.toString('hex'), copy.toString('hex'));

--- a/test/node/test-buffer-badhex.js
+++ b/test/node/test-buffer-badhex.js
@@ -17,9 +17,10 @@ const assert = require('assert');
   // Node Buffer behavior check
   // > Buffer.from('abc def01','hex')
   // <Buffer ab>
+  assert.strictEqual(buf.write('00000000', 0, 'hex'), 4);
   assert.strictEqual(buf.write('abc def01', 0, 'hex'), 1);
-  assert.deepStrictEqual(buf, new Buffer([0xab]));
-  assert.strictEqual(buf.toString('hex'), 'ab');
+  assert.deepStrictEqual(buf, new Buffer([0xab, 0, 0, 0]));
+  assert.strictEqual(buf.toString('hex'), 'ab000000');
 
   const copy = Buffer.from(buf.toString('hex'), 'hex');
   assert.strictEqual(buf.toString('hex'), copy.toString('hex'));
@@ -53,4 +54,3 @@ const assert = require('assert');
   const badHex = `${hex.slice(0, 256)}xx${hex.slice(256, 510)}`;
   assert.deepStrictEqual(Buffer.from(badHex, 'hex'), buf.slice(0, 128));
 }
-


### PR DESCRIPTION
Fixes the failing tests introduced in #303. Since the `Buffer` was 4 bytes long these comparisons couldn't ever work before.