### PR TITLE
Remove failing and redundant Standard workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,3 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm install
     - run: npm test
-
-  standard:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@main
-    - uses: actions/setup-node@main
-      with:
-        # don't use lts/* to prevent hitting rate-limit
-        node-version: 20.x
-    - run: npm install
-    - run: npm run standard


### PR DESCRIPTION
There is no script called `standard` so `npm run standard` was always failing.

Also, `standard` is already run as part of `npm test`, so it's covered by the other workflow.