### PR TITLE
README.md - fixed standalone link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ npm install buffer
 This module was previously called **native-buffer-browserify**, but please use **buffer**
 from now on.
 
-If you do not use a bundler, you can use the [standalone script](https://bundle.run/buffer).
+If you do not use a bundler, you can use the [standalone script](https://bundle.run/buffer@6.0.3).
 
 ## usage
 


### PR DESCRIPTION
Previous link: https://bundle.run/buffer <-- webpage displays internal server error
New (working) link: https://bundle.run/buffer@6.0.3