### PR TITLE
lastIndexOf: fix byteOffset when encoding passed as second arg

### DIFF
--- a/index.js
+++ b/index.js
@@ -712,7 +712,7 @@ function bidirectionalIndexOf (buffer, val, byteOffset, encoding, dir) {
   // Normalize byteOffset
   if (typeof byteOffset === 'string') {
     encoding = byteOffset
-    byteOffset = 0
+    byteOffset = undefined
   } else if (byteOffset > 0x7fffffff) {
     byteOffset = 0x7fffffff
   } else if (byteOffset < -0x80000000) {

--- a/test/methods.js
+++ b/test/methods.js
@@ -138,3 +138,12 @@ test('buffer.slice out of range', function (t) {
   t.equal((new B('hallo')).slice(10, 2).toString(), '')
   t.end()
 })
+
+test('lastIndexOf with encoding as second arg', function (t) {
+  const b = new B('abcdefghij')
+  t.equal(b.lastIndexOf('b'), 1)
+  t.equal(b.lastIndexOf('b', 'utf8'), 1)
+  t.equal(b.lastIndexOf('b', 'latin1'), 1)
+  t.equal(b.lastIndexOf('b', 'binary'), 1)
+  t.end()
+})


### PR DESCRIPTION
Currently, `buffer.lastIndexOf` behaves differently than node's Buffer when `encoding` is passed as second argument.

To reproduce the issue :
```
> node -e "console.log(require('node:buffer').Buffer.from('abcdef').lastIndexOf('b', 'utf8'))"
1
> node -e "console.log(require('buffer/').Buffer.from('abcdef').lastIndexOf('b', 'utf8'))" 
-1
```

The problem comes from the fact that, in `bidirectionalIndexOf`, when `typeof byteOffset === 'string`, the code sets `byteOffset = 0`. This is perfectly fine for `indexOf`, but breaks `lastIndexOf` (as the correct value would be the end of the buffer).

This PR fixes this, by setting `byteOffset = undefined` instead (this is what NodeJS does : https://github.com/nodejs/node/blob/main/lib/buffer.js#L980 ). It also adds a test for this.
